### PR TITLE
Updated matrix support text on contact page.

### DIFF
--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -47,7 +47,7 @@
           {{ _('<a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org" class="header-link">Live Chat on Matrix</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support in Thunderbird Chat is coming soon!') }}
+          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support is also available in Thunderbird Chat!') }}
         </p>
       </article>
     </section>

--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -47,7 +47,7 @@
           {{ _('<a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org" class="header-link">Live Chat on Matrix</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1 p-links-blue">
-          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support is also available in Thunderbird Chat!') }}
+          {{ _('You can chat with other users and members of the Thunderbird team on the <a href="https://matrix.to/#/#thunderbird:mozilla.org?web-instance%5Belement.io%5D=chat.mozilla.org">#thunderbird channel on Mozilla’s Matrix chat server</a>. You can log onto Matrix by <a href="https://wiki.mozilla.org/Matrix">following instructions on the wiki</a>. Matrix support is also available in Thunderbird!') }}
         </p>
       </article>
     </section>


### PR DESCRIPTION
Matrix support is available in TB102+. The wiki page should also be updated to include Thunderbird on the list of clients.