### PR TITLE
Rename instances of thundernest to thunderbird.

### DIFF
--- a/website/get-involved/index.html
+++ b/website/get-involved/index.html
@@ -189,10 +189,7 @@
           </p>
           <ul class="font-md tracking-wider leading-loose mb-6 p-links-blue">
             <li>
-              {{ _('<a href="https://github.com/thundernest">Thundernest</a> contains the code for Thunderbird.net (this site), as well as the Thunderbird web server setup scripts.') }}
-            </li>
-            <li>
-              {{ _('<a href="https://github.com/mozilla-comm">Thunderbird on GitHub</a> contains several Thunderbird related repositories.') }}
+              {{ _('<a href="https://github.com/thunderbird">Thunderbird on Github</a> contains the code for Thunderbird.net (this site), as well as other Thunderbird related repositories.') }}
             </li>
           </ul>
         </article>
@@ -291,7 +288,7 @@
             {{ _('You can create and improve documentation to help users on <a href="https://support.mozilla.org/en-US/products/thunderbird">SUMO, the Thunderbird user support site.</a>') }}
           </li>
           <li>
-            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thundernest/developer-docs"> on GitHub.</a>') }}
+            {{ _('You can contribute to the Thunderbird developer documentation via its repository <a href="https://github.com/thunderbird/developer-docs"> on GitHub.</a>') }}
           </li>
         </ul>
       </article>


### PR DESCRIPTION
Also removed mentions of mozilla-comm, as it seems to be no longer relevant. 