### PR TITLE
Hide the header download button if the browser is not using javascript.

### DIFF
--- a/assets/css/115-homepage.css
+++ b/assets/css/115-homepage.css
@@ -774,6 +774,11 @@ svg {
   gap: 30px;
 }
 
+/* Hide the header download button if the browser does not support javascript */
+.no-js .header-download {
+  display: none !important;
+}
+
 .nav-ln,
 .cta-ln,
 .footer-ln {

--- a/website/includes/new/page.html
+++ b/website/includes/new/page.html
@@ -24,7 +24,7 @@
         <a href="{{ url('thunderbird.115.whatsnew') }}" class="nav-ln">{{_('What’s New')}}</a>
         <a href="{{ donate_url('header') }}" class="nav-ln" data-donate-btn
           data-donate-content="header">{{_('Donate')}}</a>
-        <div>
+        <div class="header-download">
           {{ download_thunderbird(force_direct=true, hide_footer_links=true, alt_copy=_('Download')) }}
         </div>
       </div>


### PR DESCRIPTION
(Fixes #521)

Previously:
![image](https://github.com/thunderbird/thunderbird-website/assets/97147377/0b728e60-6aa4-4126-8ed0-5fda2704f0b0)

Now:
<img width="1442" alt="image" src="https://github.com/thunderbird/thunderbird-website/assets/97147377/3ce060df-9730-4dae-af03-295a9797e002">

