### PR TITLE
Add a link to the donor help form on the contact us page. (Fixes #532)

### DIFF
--- a/website/contact/index.html
+++ b/website/contact/index.html
@@ -33,12 +33,21 @@
         </p>
       </article>
 
-      <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg lg:ml-16 lg:mr-16">
+      <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg lg:ml-8 lg:mr-8">
         <h4 class="mt-0 mb-4 uppercase text-blue font-md">
           {{ _('<a href="https://support.mozilla.org/questions/new/thunderbird" class="header-link">Ask a Question</a>') }}
         </h4>
         <p class="mt-0 mb-6 flex-1">
           {{ _('You can ask a question on the support website. <b>Remember to be courteous</b>, as most of the people providing support on this site are volunteers and fellow Thunderbird users like you!') }}
+        </p>
+      </article>
+
+            <article class="flex flex-col p-4 flex-1 lg:max-w-sm mb-10 lg:mb-0 bg-white rounded shadow-lg lg:mr-8">
+        <h4 class="mt-0 mb-4 uppercase text-blue font-md">
+          {{ _('<a href="%(donor_care)s" class="header-link">Donation Support</a>')|format(donor_care=url('thunderbird.donate.contact')) }}
+        </h4>
+        <p class="mt-0 mb-6 flex-1 p-links-blue">
+          {{ _('If you have a question about a donation you\'ve made, you can contact us over at the <a href="%(donor_care)s">Donor Help page</a>. Our donor care team will be happy to assist you! The donor care team <strong>does not</strong> offer technical support, for that see our <a href="%(support)s">support page</a>.')|format(donor_care=url('thunderbird.donate.contact'), support=url('support')) }}
         </p>
       </article>
 


### PR DESCRIPTION
Feel free to suggest a better position than 3/4. The donor care page also has some preample text telling folks that they can't offer tech support, and to go to SUMO for support. (https://www.thunderbird.net/en-US/donate/help/)

![Screen Shot 2023-11-23 at 09 42 25-fullpage](https://github.com/thunderbird/thunderbird-website/assets/97147377/9facffec-73a9-435c-b3ad-5b2071df2067)
