### PR TITLE
Add holidayeoy to the `ALWAYS_LOCALIZE` setting, along with a test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ page and thunderbird.net itself.
 
 # Localization
 
+## For Contributors
+
 You can contribute to content translation of www.thunderbird.net pages using [Pontoon](https://pontoon.mozilla.org/projects/thunderbirdnet/).
+
+## For Developers
+
+Most paths under `/thunderbird` path aren't localized. There's an override setting named `ALWAYS_LOCALIZE` that allows specific paths to be forwarded to the users locale.
 
 # Donation FAQ
 

--- a/settings.py
+++ b/settings.py
@@ -99,6 +99,7 @@ ALWAYS_LOCALIZE = [
     '/appeal',
     '/eoy',
     '/beta-appeal',
+    '/holidayeoy'
 ]
 
 CANONICAL_URL = 'https://www.thunderbird.net'

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 import settings
@@ -29,3 +31,50 @@ class TestWSGI:
         for lang_in, lang_out in langs.items():
             best_lang = wsgi.get_best_language(lang_in)
             assert best_lang == lang_out
+
+    def test_always_localize_override(self):
+        """Tests our ALWAYS_LOCALIZE check during the wsgi boot process"""
+        # Formatted -> (Path, Accepts Custom Locale)
+        paths = [
+            ('/thunderbird/115.0/eoy', True),
+            ('/thunderbird/115.0/appeal', True),
+            ('/thunderbird/115.0/beta-appeal', True),
+            ('/thunderbird/115.0/holidayeoy', True),
+            ('/thunderbird/115.0/whatsnew', False),
+            ('/thunderbird', False)
+        ]
+
+        locale = 'fr'
+
+        def start_response_test(status, data: List, path):
+            """This function is called during the boot process, here we can actually do the assertions"""
+            data = dict(data)
+
+            assert 'Location' in data
+            assert path[0] in data['Location']
+            if path[1]:
+                assert locale in data['Location']
+            else:
+                assert locale not in data['Location']
+
+        for path in paths:
+            # Setup the fake env with our path and locale
+            env = {
+                'PATH_INFO': path[0],
+                'HTTP_ACCEPT_LANGUAGE': locale,
+                # Required defaults
+                'SERVER_NAME': 'localhost',
+                'GATEWAY_INTERFACE': 'CGI/1.1',
+                'SERVER_PORT': '80',
+                'REMOTE_HOST': '',
+                'CONTENT_LENGTH': '',
+                'SCRIPT_NAME': '',
+                'webob.adhoc_attrs': {
+                    'url': 'localhost',
+                    'path': path[0],
+                },
+                'wsgi.url_scheme': 'http'
+            }
+
+            # We want to also pass the current path info along, so wrap the function in a lambda
+            wsgi.application(env, lambda x, y: start_response_test(x, y, path))


### PR DESCRIPTION
This should fix up the issue. When I do the site re-write I'll have to make some time to document all of the settings and quirks of this site.

The WSGI server normally doesn't run during dev as we have a separate dev server. I should get that docker PR fixed up and out the door so dev always happens on the WSGI server. 

I've also added a test to help cover some existing paths and ensure this fix actually works before I push it up to stage and then prod.
