### PR TITLE
adds link to developer.thunderbird.net in holidayeoy

### DIFF
--- a/website/thunderbird/115.0/holidayeoy/index.html
+++ b/website/thunderbird/115.0/holidayeoy/index.html
@@ -76,7 +76,7 @@
       {{ _('<strong>Thunderbird</strong>’s mission is to offer a time and privacy-respecting, customizable communication experience that gives you control of your data and experience. <strong>Free to everyone!</strong>')}}
     </p>
     <p>
-      {{ _('Accomplishing that mission means keeping <strong>Thunderbird</strong> secure, maintaining complex server infrastructure, updating old code, fixing bugs and developing new features. <strong>These activities aren’t cheap</strong> - requiring talented software engineers and robust infrastructure.')}}
+      {{ _('Accomplishing that mission means keeping <strong>Thunderbird</strong> secure, maintaining complex server infrastructure, <a href=https://developer.thunderbird.net/>updating old code, fixing bugs and developing new features.</a> <strong>These activities aren’t cheap</strong> - requiring talented software engineers and robust infrastructure.')}}
     </p>
     <p>
       {{ _('<strong>So today we’re asking you to help us out.</strong> If you get value from using Thunderbird, please consider giving a donation to support it!')}}


### PR DESCRIPTION
To allow the non-wealthy users to contribute through their workforce, we should provide a link to our developer network in the call for contributions.