### PR TITLE
Upgrade Jinja2 from 3.0.3 to 3.1.3 and fix the build accordingly.

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -6,6 +6,7 @@ import os
 import jinja2
 import json
 import markdown
+import markupsafe
 import re
 import settings
 import sys
@@ -178,9 +179,9 @@ def high_res_img(ctx, url, optional_attributes=None, scale='1.5x', alt_formats=(
         tags.append(markup)
         tags.append('</picture>')
 
-        return jinja2.Markup("\n".join(tags))
+        return markupsafe.Markup("\n".join(tags))
 
-    return jinja2.Markup(markup)
+    return markupsafe.Markup(markup)
 
 
 @jinja2.pass_context
@@ -227,7 +228,7 @@ def platform_img(ctx, url, optional_attributes=None):
               u'<noscript><img class="platform-img w-full h-auto win" src="{win_src}" {attrs}>'
               u'</noscript>').format(attrs=attrs, win_src=img_attrs[u'data-src-windows'])
 
-    return jinja2.Markup(markup)
+    return markupsafe.Markup(markup)
 
 
 @jinja2.pass_context
@@ -314,7 +315,7 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
     template = env.get_template('includes/download-button.html')
 
     html = template.render(data)
-    return jinja2.Markup(html)
+    return markupsafe.Markup(html)
 
 
 def thunderbird_url(page, channel='None'):
@@ -387,7 +388,7 @@ def redirect_donate_url(ctx, location='thunderbird.download', make_full_url=Fals
 def safe_markdown(text):
     if not text:
         text = ''
-    return jinja2.Markup(markdown.markdown(text))
+    return markupsafe.Markup(markdown.markdown(text))
 
 
 def get_locale(lang):
@@ -437,7 +438,7 @@ def get_blog_data(ctx, entry):
 
     entry = data['entries'][entry]
 
-    parsed['summary'] = jinja2.Markup(entry['summary_detail']['value'])
+    parsed['summary'] = markupsafe.Markup(entry['summary_detail']['value'])
     parsed['title'] = entry['title']
     parsed['comments'] = entry.get('thr_total', '0')  # Comment count (atom extension)
     parsed['date'] = datetime.fromtimestamp(mktime(entry['published_parsed'])).strftime('%B %-m, %Y')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ docopt>=0.6.2
 feedparser>=5.2.1
 flake8>=3.7.7
 icalendar>=4.0.2
-jinja2>=2.10.1,<=3.0.3
+jinja2>=2.10.1,<=3.1.3
 markdown>=2.6.11
 markupsafe>=1.0
 polib>=1.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ feedparser==6.0.10
 flake8==6.0.0
 icalendar==5.0.7
 iniconfig==2.0.0
-Jinja2==3.0.3
+Jinja2==3.1.3
 Markdown==3.4.3
 MarkupSafe==2.1.2
 mccabe==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,9 +112,9 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
-jinja2==3.0.3 \
-    --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
-    --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
+jinja2==3.1.3 \
+    --hash=sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa \
+    --hash=sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90
     # via -r requirements-dev.txt
 markdown==3.4.3 \
     --hash=sha256:065fd4df22da73a625f14890dd77eb8040edcbd68794bcd35943be14490608b2 \

--- a/translate.py
+++ b/translate.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 from product_details import thunderbird_desktop as product_details
-from jinja2 import Markup
+from markupsafe import Markup
 
 import gettext
 import os


### PR DESCRIPTION
Originally #551, but we needed some additional changes to make our site build. 

As per the changelog, I've swapped `jinja2.Markup` to `markupsafe.Markup`. I've checked the instances where we use it and I can't find any issues with the change. 