### PR TITLE
Filter out versions 125.0, 126.0, 127.0 as they have no release notes - Fixes #575

### DIFF
--- a/product_details.py
+++ b/product_details.py
@@ -9,6 +9,18 @@ import re
 import settings
 
 
+def filter_major_versions(versions):
+    """Filters out some version numbers not meant for human consumption."""
+    versions_to_filter = ["125.0", "126.0", "127.0"]
+
+    # Preserves json ordering
+    for version in versions_to_filter:
+        if version in versions:
+            del versions[version]
+
+    return versions
+
+
 def load_json(path):
     """Load the .json at `path` and return data."""
     path = os.path.join(settings.JSON_PATH, path)
@@ -66,7 +78,7 @@ class ThunderbirdDetails():
 
     all_builds = load_all_builds('thunderbird_primary_builds.json')
 
-    major_releases = load_json('thunderbird_history_major_releases.json')
+    major_releases = filter_major_versions(load_json('thunderbird_history_major_releases.json'))
 
     minor_releases = load_json('thunderbird_history_stability_releases.json')
 

--- a/product_details.py
+++ b/product_details.py
@@ -11,10 +11,8 @@ import settings
 
 def filter_major_versions(versions):
     """Filters out some version numbers not meant for human consumption."""
-    versions_to_filter = ["125.0", "126.0", "127.0"]
-
     # Preserves json ordering
-    for version in versions_to_filter:
+    for version in settings.VERSIONS_TO_FILTER:
         if version in versions:
             del versions[version]
 

--- a/settings.py
+++ b/settings.py
@@ -473,3 +473,6 @@ CALENDAR_REMAP = {
     'United Kingdom': 'UK',
     'United States': 'US'
 }
+
+# Filter out specific versions for the release notes page
+VERSIONS_TO_FILTER = ["125.0", "126.0", "127.0"]


### PR DESCRIPTION
We could also make this a settings.py value. This should only affect release notes afaik.