### PR TITLE
Consistently write "macOS"

### DIFF
--- a/assets/js/common/download.js
+++ b/assets/js/common/download.js
@@ -73,7 +73,7 @@ if (typeof Mozilla === 'undefined') {
       'win': 'Windows',
       'linux64': 'Linux',
       'linux': 'Linux',
-      'osx': 'MacOS',
+      'osx': 'macOS',
       //'android': 'Android'
     };
 

--- a/product_details.py
+++ b/product_details.py
@@ -67,7 +67,7 @@ class ThunderbirdDetails():
     grouped_platform_labels = OrderedDict({
         'Windows': [('win64', '64-bit (.exe)'), ('msi', '64-bit (.msi)'), ('win', '32-bit (.exe)')],
         'Linux': [('linux64', '64-bit (binary)'), ('linux', '32-bit (binary)')],
-        'MacOS': [('osx', '64-bit (.dmg)')]
+        'macOS': [('osx', '64-bit (.dmg)')]
     })
 
     languages = load_json('languages.json')


### PR DESCRIPTION
Hey :)

Are these two occurrences supposed to be spelled "MacOS"?

grep -nr "MacOS"