### PR TITLE
Show bug numbers in preview mode with feeds template

### DIFF
--- a/sites/www.thunderbird.net/includes/release-notes-feed.html
+++ b/sites/www.thunderbird.net/includes/release-notes-feed.html
@@ -1,4 +1,4 @@
-{% set is_beta = channel_name == "Beta" %}
+{% set show_bugs = channel_name == "Beta" or is_preview|default(False) %}
 {% if notes %}
   {% set section = namespace(name='') %}
   {% set release_group = namespace(name='') %}
@@ -38,7 +38,7 @@
 
         <li>
           {{ note.note|markdown|safe }}
-          {% if is_beta %}
+          {% if show_bugs %}
             ({{ note.bug_links|markdown|safe }})
           {% endif %}
         </li>
@@ -59,7 +59,7 @@
               {{ _('Resolved in v{version_number}')|f(version_number=note.fixed_in_release.version) }}
             </a>
           {% endif %}
-          {% if is_beta %}
+          {% if show_bugs %}
             ({{ note.bug_links|markdown|safe }})
           {% endif %}
         </li>


### PR DESCRIPTION
The release announce emails use this template, and need to show bug numbers regardless of release type. Code copied over from release-notes.html template.