### PR TITLE
README: Add python version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This repo contains the Thunderbird in-client Start page and the [www.thunderbird
 # Build Instructions
 
 ## Dependencies
+
+* Python >= 3.11
+* Less
+
 On Ubuntu, you would need to use apt-get instead of yum, and similarly for different package managers.
 
 ```


### PR DESCRIPTION
Documenting Python version dependency for building (>= 3.11). This is due to UTC alias that was added in 3.11: 

https://docs.python.org/3/library/datetime.html#datetime.UTC

And throwing "Less" in the bullet points as well just for visual completeness before the instructions :smiley: .