### PR TITLE
Check both Thunderbird_esr_next and Thundebird_esr for the latest version

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -403,7 +403,7 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
     return markupsafe.Markup(html)
 
 
-def thunderbird_url(page, channel='None'):
+def thunderbird_url(page, channel=None):
     """
     Return a product-related URL like /thunderbird/all/ or /thunderbird/beta/60.0/releasenotes/.
     page = ('system-requirements', 'all', 'releasenotes')

--- a/product_details.py
+++ b/product_details.py
@@ -83,9 +83,9 @@ class ThunderbirdDetails():
     dev_releases = load_json('thunderbird_history_development_releases.json')
 
     version_map = {
-        'daily': 'LATEST_THUNDERBIRD_NIGHTLY_VERSION',
-        'beta': 'LATEST_THUNDERBIRD_DEVEL_VERSION',
-        'release': 'LATEST_THUNDERBIRD_VERSION',
+        'daily': ('LATEST_THUNDERBIRD_NIGHTLY_VERSION',),
+        'beta': ('LATEST_THUNDERBIRD_DEVEL_VERSION',),
+        'release': ('THUNDERBIRD_ESR_NEXT', 'THUNDERBIRD_ESR'),
     }
 
     channel_labels = OrderedDict({
@@ -96,8 +96,15 @@ class ThunderbirdDetails():
 
     def latest_version(self, channel='release'):
         """Returns the latest release version of Thunderbird by default, or other `channel`."""
-        version_name = self.version_map.get(channel, 'LATEST_THUNDERBIRD_VERSION')
-        return self.current_versions[version_name]
+        # Force release by default
+        version_names = self.version_map.get(channel or 'release')
+
+        version = self.current_versions.get(version_names[0])
+        # ESR_NEXT can be an empty string, so we have to fallback to ESR
+        if len(version_names) > 1 and version == '':
+            version = self.current_versions.get(version_names[1])
+
+        return version
 
     def latest_builds(self, locale, channel='release'):
         """Returns builds for the latest version of Thunderbird based on `channel`."""


### PR DESCRIPTION
Part of #559 

This frees up `LATEST_THUNDERBIRD_VERSION` for use with monthly releases.

I ran into a fun issue where thunderbird_url had a default value of 'None' as a string. So I fixed that and nothing seems out of order.