### PR TITLE
Adjustments to allow monthly releases (Or "Releases") to be downloaded.

### DIFF
--- a/build-site.py
+++ b/build-site.py
@@ -57,7 +57,8 @@ elif args.downloadlegal:
 else:
     print('Rendering www.thunderbird.net ' + langmsg)
     # Prepare data and build main website.
-    version = helper.thunderbird_desktop.latest_version('release')
+    default_channel = settings.DEFAULT_RELEASE_VERSION
+    version = helper.thunderbird_desktop.latest_version(default_channel)
     beta_version = helper.thunderbird_desktop.latest_version('beta')
 
     if os.path.exists('media/caldata/autogen/calendars.json'):
@@ -79,7 +80,8 @@ else:
                'CALDATA_URL': settings.CALDATA_URL,
                'latest_thunderbird_version': version,
                'latest_thunderbird_beta_version': beta_version,
-               'blog_data': feedparser.parse(settings.BLOG_FEED_URL)
+               'blog_data': [],
+               'default_channel': default_channel
                }
 
     site = builder.Site(languages, settings.WEBSITE_PATH, settings.WEBSITE_RENDERPATH,

--- a/helper.py
+++ b/helper.py
@@ -235,7 +235,7 @@ def platform_img(ctx, url, optional_attributes=None):
 
 
 @jinja2.pass_context
-def download_url(ctx, platform_os, version=None, channel='release', locale=None):
+def download_url(ctx, platform_os, version=None, channel=settings.DEFAULT_RELEASE_VERSION, locale=None):
     """Return a specific download url for a given version, platform, channel and optionally force a locale"""
     if locale is None:
         locale = ctx.get('LANG')
@@ -254,7 +254,7 @@ def download_url(ctx, platform_os, version=None, channel='release', locale=None)
 
 
 @jinja2.pass_context
-def has_localized_download(ctx, locale, channel='release'):
+def has_localized_download(ctx, locale, channel=settings.DEFAULT_RELEASE_VERSION):
     """Determine if a locale has a localized download link (or if it just defaults to en-US)"""
     return bool(thunderbird_desktop.latest_builds(locale, channel))
 
@@ -317,7 +317,7 @@ def get_channels(ctx, include_mobile=False):
 
 
 @jinja2.pass_context
-def download_thunderbird(ctx, channel='release', dom_id=None,
+def download_thunderbird(ctx, channel=settings.DEFAULT_RELEASE_VERSION, dom_id=None,
                          locale=None, force_direct=False,
                          alt_copy=None, button_class=None,
                          section='header', flex_class=None,
@@ -325,7 +325,7 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
     """ Output a "Download Thunderbird" button.
 
     :param ctx: context from calling template.
-    :param channel: name of channel: 'release', 'beta' or 'daily'. 'alpha' has been retired.
+    :param channel: name of channel: 'esr', 'release', 'beta' or 'daily'. 'alpha' has been retired.
     :param dom_id: Use this string as the id attr on the element.
     :param locale: The locale of the download. Default to locale of request.
     :param force_direct: Force the download URL to be direct.
@@ -336,7 +336,7 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
     :param hide_footer_links: Whether we should hide the footer links (System Requirements, What's New, Privacy Policy) display. Default to 'False'.
     :return: The button html.
     """
-    alt_channel = '' if channel == 'release' else channel
+    alt_channel = '' if channel == settings.DEFAULT_RELEASE_VERSION else channel
     locale = ctx.get('LANG', None)
     dom_id = dom_id or 'download-button-desktop-%s' % channel
 
@@ -413,7 +413,7 @@ def thunderbird_url(page, channel=None):
         {{ thunderbird_url('system-requirements', channel) }}
     """
 
-    channel = channel or 'release'
+    channel = channel or settings.DEFAULT_RELEASE_VERSION
     version = thunderbird_desktop.latest_version(channel)
     # replace 'b1', 'b2' etc in beta version with just 'beta', since we don't generate
     # new notes for each beta iteration.
@@ -423,7 +423,7 @@ def thunderbird_url(page, channel=None):
 
     if page == 'all':
         url = '/en-US/thunderbird/{0}/{1}/'.format(channel, page)
-        if channel == 'release':
+        if channel in ['release', 'esr']:
             url = '/en-US/thunderbird/{0}/'.format(page)
 
     return url

--- a/product_details.py
+++ b/product_details.py
@@ -90,21 +90,23 @@ class ThunderbirdDetails():
     version_map = {
         'daily': ('LATEST_THUNDERBIRD_NIGHTLY_VERSION',),
         'beta': ('LATEST_THUNDERBIRD_DEVEL_VERSION',),
-        'release': ('THUNDERBIRD_ESR_NEXT', 'THUNDERBIRD_ESR'),
+        'esr': ('THUNDERBIRD_ESR_NEXT', 'THUNDERBIRD_ESR'),
+        'release': ('LATEST_THUNDERBIRD_VERSION',),
         # Win7/8.1 only support up to 115
         'release_win7_8': ('THUNDERBIRD_ESR',)
     }
 
     channel_labels = OrderedDict({
+        'esr': 'Extended Support Release',
         'release': 'Release',
         'beta': 'Beta',
         'daily': 'Daily'
     })
 
-    def latest_version(self, channel='release'):
+    def latest_version(self, channel=settings.DEFAULT_RELEASE_VERSION):
         """Returns the latest release version of Thunderbird by default, or other `channel`."""
         # Force release by default
-        version_names = self.version_map.get(channel or 'release')
+        version_names = self.version_map.get(channel or settings.DEFAULT_RELEASE_VERSION)
 
         version = self.current_versions.get(version_names[0])
         # ESR_NEXT can be an empty string, so we have to fallback to ESR
@@ -113,7 +115,7 @@ class ThunderbirdDetails():
 
         return version
 
-    def latest_builds(self, locale, channel='release'):
+    def latest_builds(self, locale, channel=settings.DEFAULT_RELEASE_VERSION):
         """Returns builds for the latest version of Thunderbird based on `channel`."""
         version = self.latest_version(channel)
 
@@ -194,7 +196,7 @@ class ThunderbirdDetails():
                              ('lang', _locale),
                          ])])
 
-    def platforms(self, channel='release'):
+    def platforms(self, channel=settings.DEFAULT_RELEASE_VERSION):
         return self.platform_labels.items()
 
     def list_releases(self):

--- a/settings.py
+++ b/settings.py
@@ -503,3 +503,7 @@ WEBSITE_REDIRECTS = {
     ('thunderbird', '128.0esr', 'whatsnew'): 'thunderbird.128.whatsnew',
     ('thunderbird', '128.0', 'releasenotes'): 'thunderbird.128esr.releasenotes',
 }
+
+# The default release channel to use when various function defaults are used
+# This will change the channel of the main download button.
+DEFAULT_RELEASE_VERSION = 'esr'

--- a/sites/www.thunderbird.net/includes/base/base.html
+++ b/sites/www.thunderbird.net/includes/base/base.html
@@ -54,6 +54,7 @@
     <script>
       window.siteLocale = "{{ LANG }}";
     </script>
+    {% include 'includes/javascript-metadata.html' %}
   </head>
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>

--- a/sites/www.thunderbird.net/includes/download-button.html
+++ b/sites/www.thunderbird.net/includes/download-button.html
@@ -15,7 +15,7 @@
     <ul class="list-none p-0 flex flex-wrap max-w-lg {{ flex_class }}">
       {% for plat in builds -%}
         <li class="ml-3 mr-3">
-          <a href="{{ plat.download_link_direct or plat.download_link }}" class="matomo-track-download download-link {{ button_class }}" data-donate-redirect="download-{{ channel or 'esr' }}" data-donate-content="post_download" data-donate-link="{{ redirect_donate_url(content='post_download', download=True, download_channel=channel or 'esr') }}">
+          <a href="{{ plat.download_link_direct or plat.download_link }}" class="matomo-track-download download-link {{ button_class }}" data-donate-redirect="download-{{ channel or default_channel }}" data-donate-content="post_download" data-donate-link="{{ redirect_donate_url(content='post_download', download=True, download_channel=channel or default_channel) }}">
             {{ plat.os_arch_pretty or plat.os_pretty }}
           </a>
         </li>
@@ -77,9 +77,9 @@
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
         <a class="matomo-track-download download-link {{ button_class }}"
           href="{{ plat.download_link }}"
-          data-donate-redirect="download-{{ channel or 'esr' }}"
+          data-donate-redirect="download-{{ channel or default_channel }}"
           data-donate-content="post_download"
-          data-donate-link="{{ redirect_donate_url(content='post_download', download=True, download_channel=channel or 'esr') }}"
+          data-donate-link="{{ redirect_donate_url(content='post_download', download=True, download_channel=channel or default_channel) }}"
           {% if plat.download_link_direct %}
             data-direct-link="{{ plat.download_link_direct }}"
           {% endif %}>

--- a/sites/www.thunderbird.net/includes/javascript-metadata.html
+++ b/sites/www.thunderbird.net/includes/javascript-metadata.html
@@ -1,0 +1,17 @@
+{# Outputs static metadata for any javascript scripts to use. #}
+<script>
+  window._product = {
+    defaultChannel: '{{ default_channel }}',
+    defaultLatestVersion: '{{ get_latest_build(default_channel) }}',
+    channels: {
+      {% for channel, channel_name in get_channels().items() %}
+        '{{ channel }}': {
+          id: '{{ channel }}',
+          name: '{{ channel_name }}',
+          version: '{{ get_latest_build(channel) }}',
+          useVersionInDownloadLinks: {% if channel in ['release', 'esr'] %}true{% else %}false{% endif %},
+        },
+      {% endfor %}
+    }
+  }
+</script>

--- a/sites/www.thunderbird.net/thunderbird/all/index.html
+++ b/sites/www.thunderbird.net/thunderbird/all/index.html
@@ -25,6 +25,9 @@
           <div id="daily-warning" class="warning-panel hidden">
             <p>{{ _('The Daily version is an unstable testing and development platform, make sure you back up important data regularly!') }}</p>
           </div>
+          <div id="release-warning" class="warning-panel hidden">
+            <p>{{ _('Thunderbird Release is available for testing purposes only until releases are deemed stable enough for official support. Make sure you backup important data regularly!') }}</p>
+          </div>
 
           <!-- 1. Locale -->
           <label class="pretend-to-be-h6" for="download-language-select" role="group">
@@ -46,7 +49,7 @@
           </label>
           <select id="download-release-select" name="download" dir="ltr" class="form-select">
             {% for channel, channel_name in get_channels().items() %}
-            {% set option_name = 'Thunderbird %(channel_name)s'|format(channel_name=channel_name) if channel != 'release' else 'Thunderbird' %}
+            {% set option_name = 'Thunderbird %(channel_name)s'|format(channel_name=channel_name) %}
             <option value="{{ channel }}">{{ _(option_name) }}</option>
             {% endfor %}
           </select>
@@ -135,7 +138,7 @@
                 <a class="dotted" href="{{ url('thunderbird.sysreq', latest_thunderbird_version) }}">{{ _('System Requirements') }}</a>
               </li>
               <li>
-                <a class="dotted" href="{{ thunderbird_url('releasenotes', 'release') }}">{{ _('Release Notes') }}</a>
+                <a class="dotted" href="{{ thunderbird_url('releasenotes', default_channel) }}">{{ _('Release Notes') }}</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
* Add a DEFAULT_RELEASE_VERSION and use that for any version defaults.
* Some pre-built metadata for javascript.
* Add a warning about Thunderbird Releases.

Fixes #559 

I'm not sure why I wasn't using a pre-built javascript metadata script tag, but now I am. Other random script tags we have will slowly migrate to that file. 

Here I've split release into the in-testing monthly releases, and esr which will server...esr builds. I've also added a default setting so we can flip it to release in the future with hopefully minimal issues. 

### Screenshots

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/a0a52e42-8a01-42bd-97d3-8b4a3fad4dd0">
<img width="708" alt="image" src="https://github.com/user-attachments/assets/f0907c89-b813-4b8e-8de6-522c59fc9295">
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/2943f201-8ee2-46fa-95c3-d873d2764941">
