### PR TITLE
Add readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+ python:
+    install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
- python:
+python:
     install:
     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains the Thunderbird in-client Start page, the [www.thunderbird.ne
 * The `prod` branch is used to update https://start.thunderbird.net, https://www.thunderbird.net, and https://updates.thunderbird.net.
 * The `master` branch is used to update https://start-stage.thunderbird.net, https://www-stage.thunderbird.net, and https://updates-stage.thunderbird.net.
 
-Additional information can be found in our [readthedocs documentation](https://thunderbird-website.readthedocs.io/en/latest/).
+Additional information can be found in our [readthedocs documentation](https://docs.thunderbird.net/en/latest/).
 
 # Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repo contains the Thunderbird in-client Start page, the [www.thunderbird.ne
 * The `prod` branch is used to update https://start.thunderbird.net, https://www.thunderbird.net, and https://updates.thunderbird.net.
 * The `master` branch is used to update https://start-stage.thunderbird.net, https://www-stage.thunderbird.net, and https://updates-stage.thunderbird.net.
 
+Additional information can be found in our [readthedocs documentation](https://thunderbird-website.readthedocs.io/en/latest/).
+
 # Build Instructions
 
 ## Dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,8 @@
 # -- Project information
 
 project = 'Thunderbird Websites'
-copyright = '2024, Mozilla'
-author = 'Mozilla'
+copyright = '2024, MZLA Technologies Corporation'
+author = 'MZLA Technologies Corporation'
 
 release = '0.1'
 version = '0.1.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,9 +2,9 @@
 
 # -- Project information
 
-project = 'Lumache'
-copyright = '2021, Graziella'
-author = 'Graziella'
+project = 'Thunderbird Websites'
+copyright = '2024, Mozilla'
+author = 'Mozilla'
 
 release = '0.1'
 version = '0.1.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx_rtd_light_dark',
+    'myst_parser',
 ]
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
-    'sphinx_rtd_light_dark',
     'myst_parser',
 ]
+# removing sphinx_rtd_light_dark extension because:
+# sphinx.errors.ThemeError: An error happened in rendering the page archived.
+# Reason: UndefinedError("'style' is undefined")
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
@@ -31,7 +33,8 @@ templates_path = ['_templates']
 
 # -- Options for HTML output
 
-html_theme = 'sphinx_rtd_light_dark'
+#html_theme = 'sphinx_rtd_light_dark'
+html_theme = 'sphinx_rtd_theme'
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@
 
 project = 'Thunderbird Websites'
 copyright = '2024, MZLA Technologies Corporation'
-author = 'MZLA Technologies Corporation'
+author = 'Thunderbird Services'
 
 release = '0.1'
 version = '0.1.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,36 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = 'Lumache'
+copyright = '2021, Graziella'
+author = 'Graziella'
+
+release = '0.1'
+version = '0.1.0'
+
+# -- General configuration
+
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'sphinx_rtd_light_dark',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+intersphinx_disabled_domains = ['std']
+
+templates_path = ['_templates']
+
+# -- Options for HTML output
+
+html_theme = 'sphinx_rtd_light_dark'
+
+# -- Options for EPUB output
+epub_show_urls = 'footnote'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,9 @@
+=========================================
+Welcome to Thunderbird Websites documentation!
+=========================================
+
+Contents
+--------
 .. toctree::
    :maxdepth: 2
    :caption: Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+.. toctree::
+   :maxdepth: 2
+   :caption: Documentation
+   
+   archived.md
+   updates.thunderbird.net.md
+   less-styling.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==8.1.3 
+sphinx-rtd-light-dark==0.1.2 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==8.1.3 
 sphinx-rtd-light-dark==0.1.2 
+myst-parser~=4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==8.1.3 
-sphinx-rtd-light-dark==0.1.2 
-myst-parser~=4.0
+sphinx
+sphinx-rtd-theme
+myst-parser


### PR DESCRIPTION
We're moving toward standardizing the docs we generate in web services, so let's start here as we have some docs to write for how to update TB websites.

You can see the generated docs here: https://thunderbird-website.readthedocs.io/en/latest/

Right now, it's just using the .md files in the docs/ folder, we can hook up python autodoc (or other tool) to generate API docs after