### PR TITLE
Make privacy links easier for google

### DIFF
--- a/assets/less/pages/privacy.less
+++ b/assets/less/pages/privacy.less
@@ -7,6 +7,18 @@
     max-inline-size: 90%;
     text-align: left;
   }
+  .sidebar {
+    align-self: flex-start;
+    margin: 1.8rem 0;
+    padding: 0;
+    width: 100%;
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      list-style-type: none;
+      padding: .67rem 1rem .67rem 0;
+    }
+  }
 }
-
-

--- a/sites/www.thunderbird.net/includes/base/footer.html
+++ b/sites/www.thunderbird.net/includes/base/footer.html
@@ -33,7 +33,6 @@
           <li><a href="{{ url('thunderbird.about') }}" class="dotted">{{_('Who We Are')}}</a></li>
           <li><a href="{{ url('thunderbird.contact') }}" class="dotted">{{_('Contact Us')}}</a></li>
           <li><a href="{{ url('mozorg.careers.tb') }}" class="dotted">{{_('Careers')}}</a></li>
-          <li><a href="{{ url('thunderbird.privacy') }}" class="dotted">{{_('Thunderbird Privacy')}}</a></li>
         </ul>
       </div>
       <div class="site-link-section">
@@ -49,8 +48,8 @@
         {{ svg('Mozilla_Logo') }}
       </a>
       <div class="legal-links">
-        <a href="{{ url('privacy') }}" data-link-type="footer"
-        data-link-name="Privacy">{{ _('Privacy') }}</a>
+        <a href="{{ url('thunderbird.privacy') }}" data-link-type="footer"
+        data-link-name="Privacy">{{ _('Privacy Policy') }}</a>
         <a href="{{ url('privacy.notices.websites') }}" data-link-type="footer"
           data-link-name="Cookies">{{ _('Cookies') }}</a>
         <a href="{{ url('legal.index') }}" data-link-type="footer"

--- a/sites/www.thunderbird.net/privacy/index.html
+++ b/sites/www.thunderbird.net/privacy/index.html
@@ -11,10 +11,21 @@
 {% block content %}
 <section>
   <div class="container">
-    <div class="section-text">
-    {# This is downloaded from build-site.py but should be checked into the repo. #}
-    {% include 'includes/privacy/privacy-desktop.html' %}
-    </div>
-  </div>
+    <div class="two-columns">
+      <div class="column sidebar">
+        <div class="section-text">
+          <ul>
+            <li><b>{{ _('Thunderbird Privacy Policy') }}</b></li>
+            <li><a href="https://www.mozilla.org/privacy/websites/">{{ _('Website Privacy Policy') }}</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="column">
+        <div class="section-text">
+          {# This is downloaded from build-site.py but should be checked into the repo. #}
+          {% include 'includes/privacy/privacy-desktop.html' %}
+        </div>
+      </div>
+    </div>  </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
Closes #707 

## Add and style a sidebar to the `/privacy` page:
![Screenshot_20241122_134428](https://github.com/user-attachments/assets/95b8d20c-365a-4417-8e07-ac3f53f11949)

## Reduce number of privacy links in footer:
![Screenshot_20241122_134707](https://github.com/user-attachments/assets/24f8e98f-44e0-4c66-a1a8-34a8131ff8c2)
