### PR TITLE
Adjust background for certain breakpoints.

### DIFF
--- a/assets/less/appeals/dec24.less
+++ b/assets/less/appeals/dec24.less
@@ -51,10 +51,10 @@
 
     --bg-color: linear-gradient(to bottom, rgba(20, 64, 92, 0) 12%, #0f345e 22%);
 
-    --bg-position: center 9rem, calc(100%) top;
-    --bg-position-mxl: center 7.5rem, calc(100%) top;
+    --bg-position: center 8rem, calc(100%) top;
+    --bg-position-mxl: center 6.5rem, calc(100%) top;
     --bg-position-xl: center 8.5rem, calc(100%) top;
-    --bg-position-lg: center 3.5rem, calc(100%) top;
+    --bg-position-lg: center 2.5rem, calc(100%) top;
     --bg-position-md: center -3.5rem, calc(100%) top;
     --bg-position-sm: center 3.5rem, calc(100% + 2.3rem) top;
     --bg-position-ss: center -1.5rem, calc(100% + 2.3rem) top;


### PR DESCRIPTION
For some breakpoints, there was a gap between the background image and the background gradient.

This PR makes the gaps go away.