### PR TITLE
Update the monthly releases start page (Fixes #677)

### DIFF
--- a/assets/less/start.less
+++ b/assets/less/start.less
@@ -159,6 +159,15 @@
   --list-dot-outer: var(--teal-10);
 }
 
+[data-channel="release"] {
+  --text-gradient: linear-gradient(-270deg, var(--teal-50), var(--blue-50));
+  --bg-warning: color-mix(in srgb, var(--teal-50) 5%, transparent);
+  --text-warning: var(--teal-90);
+  --warning-links: var(--blue-80);
+  --list-dot-inner: var(--teal-90);
+  --list-dot-outer: var(--teal-10);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: var(--grey-05);
@@ -183,6 +192,15 @@
   }
 
   [data-channel="beta"] {
+    --text-gradient: linear-gradient(-270deg, var(--teal-40), var(--blue-40));
+    --bg-warning: color-mix(in srgb, var(--teal-50) 5%, transparent);
+    --text-warning: var(--teal-10);
+    --warning-links: var(--blue-30);
+    --list-dot-inner: var(--teal-30);
+    --list-dot-outer: var(--teal-90);
+  }
+
+  [data-channel="release"] {
     --text-gradient: linear-gradient(-270deg, var(--teal-40), var(--blue-40));
     --bg-warning: color-mix(in srgb, var(--teal-50) 5%, transparent);
     --text-warning: var(--teal-10);

--- a/sites/start.thunderbird.net/monthly/index.html
+++ b/sites/start.thunderbird.net/monthly/index.html
@@ -2,26 +2,129 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-<!DOCTYPE html>
-<html lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}">
-<head>
-  <meta charset="utf-8">
-  <meta name="robots" content="noindex">
-  <title>{% block title %}{{ _('Unsupported Thunderbird Version!') }}{% endblock %}</title>
-  {{ l10n_css() }}
-  <style>
-    body {
-      background-color: #D46A6A;
-      text-align: center;
-    }
-  </style>
-</head>
-<body>
-<main>
-  <h1><b>{{ _('This is an unsupported version of Thunderbird!!') }}</b></h1>
-  <h2>{{ _('Thunderbird monthly releases are not considered stable for general use.') }}</h2>
-  <p><i>{{ _('Use at your own risk, this build is the same quality as Thunderbird Beta.') }}</i></p>
-  <p><b>{{ _('We recommend downloading the <a href="%(download_url)s">latest stable version of Thunderbird</a>.')|format(download_url='https://www.thunderbird.net') }}</b></p>
-</main>
-</body>
-</html>
+{% extends "_base-resp.html" %}
+
+{% block channel %}release{% endblock %}
+{% block title %}{{ _('Welcome to <div class="tb-text">Thunderbird</div>') }}{% endblock %}
+
+{% block main %}
+      <header>
+        <div class="header-top">
+          <div class="title">
+            <div class="logo-img"></div>
+            <h1 class="title-text">{{ self.title() }}</h1>
+          </div>
+
+          <div class="donate">
+            {{ _('Support us!') }}
+            {{ '<a href="%(donate)s" class="donate-btn" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_monthly">'|format(donate=redirect_donate_url(content='paragraph_text', source='start_page_tb_release', location='thunderbird.donate', make_full_url=True, show_donation_modal=False)) }}
+              {{ svg('donate-btn-heart') }}
+              {{ _('Donate') }}
+            </a>
+          </div>
+        </div>
+
+      <div class="warning-panel">
+          <div>
+            <p class="warning">
+              {{ svg('beta-warning') }}
+              <strong class="uppercase">{{ _('Warning!') }}</strong>
+              {{ _('Monthly release builds can be unstable, and there is potential to lose data.') }}
+            </p>
+            {# Pending release specific articles #}
+            {#
+            <ul>
+              <li>
+                {{ _('Protect your data and other best practices.') }}
+                <a href="https://support.mozilla.org/kb/thunderbird-beta" class="warning">
+                  {{ _('Knowledge Base') }}
+                  {{ svg('external-link') }}
+                </a>
+              </li>
+              <li>
+                {{ _('Add-ons may not work properly, or not work at all.') }}
+                <a href="https://support.mozilla.org/kb/thunderbird-beta#w_add-ons" class="warning">
+                  {{ _('Add-ons Guide') }}
+                  {{ svg('external-link') }}
+                </a>
+              </li>
+            </ul>
+            #}
+          </div>
+        </div>
+      </header>
+
+      <div class="main-content">
+        <div class="content-sections">
+          <section id="donate">
+            <h2 class="section-heading donate">
+              {{ svg('donate-heart') }}
+              {{ _('Support Us') }}
+            </h2>
+            <p>{{ _('Thank you for supporting Thunderbird, which is funded by users like you! Producing Thunderbird requires software engineers, designers, system administrators and server infrastructure. So if you like Thunderbird, the best way to ensure Thunderbird remains available is to make a donation.') }}</p>
+            {{ '<a href="%(donate)s" class="donate" data-donate-btn data-donate-redirect="donate" data-donate-content="paragraph_text" data-donate-source="start_page_tb_release">'|format(donate=redirect_donate_url(content='paragraph_text', source='start_page_tb_release', location='thunderbird.donate', make_full_url=True, show_donation_modal=False)) }}
+              {{ _('Donate') }}
+              {{ svg('external-link') }}
+            </a>
+          </section>
+
+          <section id="get-involved">
+            <h2 class="section-heading get-involved">
+              {{ svg('handshake') }}
+              {{ _('Help') }}
+            </h2>
+            <p>{{ _('Curious about helping? You don’t need to be an expert or know how to code to help other users or offer suggestions about improving the experience! Join us in this open source project where anyone can participate in the Thunderbird community.') }}</p>
+            <a href="https://www.thunderbird.net/participate/" class="get-involved">
+              {{ _('Get Involved') }}
+              {{ svg('external-link') }}
+            </a>
+            <p>{{ _('Share ideas and feedback.') }}</p>
+            <a href="https://connect.mozilla.org/" class="get-involved">
+              {{ _('Mozilla Connect') }}
+              {{ svg('external-link') }}
+            </a>
+          </section>
+        </div>
+
+        <div class="content-sections">
+          <section id="support">
+            <h2 class="section-heading support">
+              {{ svg('support') }}
+              {{ _('Questions? Problems?') }}
+            </h2>
+            <p>{{ _('Post your general Thunderbird usage questions or problems on the support page, where many knowledgeable users can help you.') }}</p>
+            <a href="https://support.mozilla.org/questions/new/thunderbird" class="support">
+              {{ _('Support Page') }}
+              {{ svg('external-link') }}
+            </a>
+          </section>
+
+          <section id="bug">
+            <h2 class="section-heading bug">
+              {{ svg('bug') }}
+              {{ _('Report') }}
+            </h2>
+            <p>{{ _('Think you’ve found a new problem or rough edge? Create a bug report so we can make sure it gets solved, resulting in a better Thunderbird experience for all.') }}</p>
+            <a href="https://bugzilla.mozilla.org/describecomponents.cgi?product=Thunderbird" class="bug">
+              {{ _('Report a Bug') }}
+              {{ svg('external-link') }}
+            </a>
+          </section>
+
+          <section id="crash">
+            <h2 class="section-heading crash">
+              {{ svg('info') }}
+              {{ _('Crashed?') }}
+            </h2>
+            <p>{{ _('If Crash Reporter appears when Thunderbird crashes, please provide as many details as possible to help developers.') }}</p>
+            <ul>
+              <li>{{ _('In Thunderbird do Help > More Troubleshooting Information, scroll to "Crash Reports", click a recent report link to open the crash report page.') }}</li>
+              <li>{{ _('Click the Bugzilla tab, then click on an existing bug report under "Related Bugs" and add a comment to the bug, or click "Thunderbird" to submit a new bug report.') }}</li>
+            </ul>
+            <a href="https://support.mozilla.org/en-US/kb/mozilla-crash-reporter-tb" class="crash">
+              {{ _('Crash Reporter') }}
+              {{ svg('external-link') }}
+            </a>
+          </section>
+      </div>
+{% endblock %}


### PR DESCRIPTION
cc @coreycb 

![Screen Shot 2024-12-03 at 10 44 25-fullpage](https://github.com/user-attachments/assets/8c307743-4b4d-49bc-9aea-a3cf27ea8655)

Open to suggestions on language adjustments, links, colours, etc...

Simple copy and paste from releases with a tweaked beta banner right now. 