### PR TITLE
Update legal to 2024-12-09

### DIFF
--- a/sites/www.thunderbird.net/includes/privacy/privacy-desktop.html
+++ b/sites/www.thunderbird.net/includes/privacy/privacy-desktop.html
@@ -1,8 +1,9 @@
 {# THIS PAGE IS AUTOMATICALLY GENERATED, DO NOT EDIT THIS DOCUMENT! #}
 <h1>Thunderbird Privacy Notice</h1>
-<p datetime="2024-11-15">Last updated November 15, 2024</p>
+<p datetime="2024-12-09">Last updated December 9, 2024</p>
 <p>The Thunderbird Desktop, Thunderbird for Android, and K-9 Mail applications (together, “Thunderbird”) allow users to privately integrate and manage their online communications. K-9 Mail is a variant of Thunderbird for Android. All references to “Thunderbird” or “Thunderbird for Android” apply equally to K-9 Mail.</p>
 <p>This Privacy Notice explains what data Thunderbird collects and shares, and why. We also adhere to the <a href="https://www.mozilla.org/privacy/">Mozilla Privacy Policy</a> for how we receive, handle, and share information.</p>
+<p>This privacy notice is for the most recent general release version of Thunderbird distributed by MZLA Technologies Corporation (a subsidiary of Mozilla Foundation). If you obtain Thunderbird elsewhere, or are running an older version, your copy of Thunderbird may contain different privacy characteristics.</p>
 <h2>Thunderbird Collects Data To:</h2>
 <h3>Improve Performance, Stability, and Functionality For Our Users</h3>
 <p>Thunderbird sends telemetry about your interactions with Thunderbird to us. There are two types of telemetry data: interaction data and technical data.</p>
@@ -42,10 +43,21 @@
 <p><strong>Technical data for updates</strong>: Thunderbird periodically connects to our server to install updates to add-ons. Your installed add-ons, application version, language, and device operating system are used to apply the correct updates. When Thunderbird sends technical data to us, your IP address is temporarily collected as part of our server logs.</p>
 <h2>Use of OAuth Information</h2>
 <p>OAuth is a secure authorization protocol that allows third-party applications to access resources without sharing login credentials. Thunderbird uses OAuth to connect with certain email or calendar providers that mandate or prefer its use, such as Google, Yahoo and Microsoft.</p>
-<p>When using OAuth to authorize access to your email or calendars, all data is strictly exchanged over an encrypted connection between the email client application and the OAuth service. Mozilla does not collect, access, or store any sensitive information exchanged during this process.</p>
-<p>On your device, login credentials are not retained; instead, they are exchanged for OAuth tokens. These tokens, along with your email and calendar data, are stored within the application sandbox (on Android) or confined within your user profile (on Desktop). When you remove an account, all associated content and tokens will be deleted from your device. On Desktop, the tokens may be retained for a longer period of time in case you have multiple accounts, but can be removed separately in the password manager.</p>
+<p>When using OAuth to authorize access to your email or calendars, all data is strictly exchanged over an encrypted connection between the email client application and the OAuth service. Mozilla does not collect, access, retain, or store any sensitive information exchanged during this process.</p>
+<p>On your device, login credentials are not retained; instead, they are exchanged for OAuth tokens. These tokens, along with your email and calendar data, are stored within the application sandbox (on Android) or confined within your user profile (on Desktop).</p>
+<p>Your email and calendar data (including data associated with your Apple Calendar, Microsoft 365, or Google Calendars) reside solely on your device for the duration required to operate Thunderbird. When you remove an account, all associated content and tokens will be deleted from your device. On Desktop, the tokens may be retained for a longer period of time in case you have multiple accounts, but can be removed separately in the password manager.</p>
 <h2>Thunderbird May Disclose Information To:</h2>
 <p><strong>Mozilla Affiliates</strong>: Thunderbird is a project of MZLA Technologies Corporation, a subsidiary of Mozilla Foundation and an affiliate of Mozilla Corporation, and as such, shares some of the same infrastructure. This means that, from time to time, your data (e.g., crash reports, and technical and interaction data) may be disclosed to Mozilla Corporation and Mozilla Foundation. If so, it will be maintained in accordance with the commitments we make in this Privacy Notice.</p>
 <p><strong>DNS servers, Standard Autoconfiguration URIs, and Mozilla's Configuration Database</strong>: To simplify the email set-up process, Thunderbird tries to determine the correct settings for your account by contacting Mozilla’s configuration database as well as external servers. These include DNS servers and standard autoconfiguration URIs. During this process, your email domain may be sent to Mozilla's configuration database, and your email address may be disclosed to your network administrators.</p>
 <p><strong>Amazon Web Services</strong>: Thunderbird uses Amazon Web Services (AWS) to host its servers and as a content delivery network. Your device’s IP address is collected as part of AWS’s server logs.</p>
 <p><strong>Email address providers (Desktop Only Legacy)</strong>: Prior to version 128, Thunderbird partnered with Gandi.net and Mailfence to allow you to create a new email address through Thunderbird. If you choose to use this feature, your email address search terms are sent to Gandi.net and Mailfence to return available addresses. In addition, your country location is also shared to provide the correct prices. You can learn more about <a href="https://contract.gandi.net/v5/contracts/14420/Privacy_Policy_US_2.0_en.pdf">Gandi.net’s</a> and <a href="https://mailfence.com/en/privacy.jsp">Mailfence’s</a> data practices by reading their privacy notices.</p>
+<h2>Contact Us</h2>
+<p>If you want to make a correction to your information, or you have any questions about our privacy policies, please get in touch with:</p>
+<p><strong>MZLA Technologies Corporation</strong>
+Attn: Mozilla - Privacy
+149 New Montgomery St, 4th Floor,
+San Francisco, CA 94105
+USA
+compliance@mozilla.com</p>
+<p><a href="https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0">See here for Data Subject Access Requests</a>. If you are under 13, we don’t want your personal information, and you must not provide it to us. If you are a parent and believe that your child who is under 13 has provided us with personal information, please contact us to have your child’s information removed.</p>
+<p>For product support requests, please <a href="https://support.mozilla.org/">visit our forums</a>.</p>


### PR DESCRIPTION
On 2024-12-10, ran `python build-site.py  --downloadlegal`.

Resulted in changes to `sites/www.thunderbird.net/includes/privacy/privacy-desktop.html` (automatically timestamped 2024-12-09).