### PR TITLE
Add matomo-track-download to the /thunderbird/all download page. 

### DIFF
--- a/sites/www.thunderbird.net/thunderbird/all/index.html
+++ b/sites/www.thunderbird.net/thunderbird/all/index.html
@@ -90,7 +90,7 @@
         <div class="download-button download-button-page download-spacing">
             <a
               id="download-btn"
-              class="btn btn-download btn-white-bg btn-slim"
+              class="btn btn-download btn-white-bg btn-slim matomo-track-download"
               href="{{ download_url(platform_os=win64) }}"
               data-donate-redirect="download-{{ channel or 'esr' }}"
               data-donate-content="post_download"


### PR DESCRIPTION
Fixes #732

We set the download class for matomo in our matomo-config.js file, and that triggers a "Download Event" on the matomo backend. I missed adding this class to the downloads page, but it's on the "smart" download buttons so it's covered everywhere else. 
