### PR TITLE
For participate add some logic to open accordions on a fragment match (Fixes #743)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -118,3 +118,20 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 });
+
+/**
+ * For participates accordions. If we detect a valid id in the fragment, we grab the next sibling element
+ * which is the accordion/summary tag and open it. Only happens on page load.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const fragment = window.location.hash.substring(1);
+  const element = document.getElementById(fragment);
+  if (!element) {
+    return;
+  }
+  const accordionElement = element.nextElementSibling;
+  if (!accordionElement) {
+    return;
+  }
+  accordionElement.setAttribute('open', 'open');
+});

--- a/assets/less/pages/participate.less
+++ b/assets/less/pages/participate.less
@@ -87,4 +87,9 @@
       text-decoration-style: dotted;
     }
   }
+
+  .anchor-link {
+    position: relative;
+    top: calc(-1 * var(--nav-height));
+  }
 }

--- a/sites/www.thunderbird.net/participate/index.html
+++ b/sites/www.thunderbird.net/participate/index.html
@@ -210,6 +210,8 @@
 :param title: The title of the accordion
 :caller: The text body, shows up when you click on the title or accordion.
 #}
+  {# This is here to account for the navbar height #}
+  <div aria-hidden="true" class="anchor-link" id="{{ title|lower|replace(' ', '-') }}"></div>
   <details class="accordion">
     <summary class="question">
       <span>{{ icon }}</span>


### PR DESCRIPTION
I do wish there was a native way to open detail/summary tags if a fragment matched, but ah well. Also added the id to a hidden div that sits just above the accordion so the nav doesn't cover it. 