### PR TITLE
Add the announcement and clean up some announcement css (Fixes #769)

### DIFF
--- a/assets/less/new/components/announcement.less
+++ b/assets/less/new/components/announcement.less
@@ -1,5 +1,13 @@
 :root {
+  /* Adjust these as needed by the text amount */
   --site-announcement-height: 2.625rem; // 42px;
+  --site-announcement-padding: 0rem;
+
+  @media (max-width: @sm) {
+    --site-announcement-height: 4.25rem; // 68px;
+    --site-announcement-padding: 0;
+  }
+
 }
 
 .site-announcement {
@@ -7,6 +15,8 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  padding: var(--site-announcement-padding);
+  text-align: center;
 
   position: absolute;
   top: 0;
@@ -18,6 +28,10 @@
   color: var(--color-white);
   font-size: 80%;
   font-weight: 500;
+}
+
+.site-announcement > .strong::after {
+  top: 0.22rem;
 }
 
 .site-announcement ~ .site-nav {

--- a/settings.py
+++ b/settings.py
@@ -561,3 +561,7 @@ FRU_FORM_IDS = {
 
 # Flip to True to display a "Response times may be slower than usual" warning on the donor help form.
 DONOR_HELP_SLOW_WARNING = False
+
+# Turning this value to True will enable a thunderbird.net site-wide announcement banner
+# Make sure to edit it in includes/announcement.html !
+SITE_ANNOUNCEMENT = True

--- a/sites/www.thunderbird.net/includes/announcement.html
+++ b/sites/www.thunderbird.net/includes/announcement.html
@@ -1,1 +1,8 @@
-<div class="site-announcement"></div>
+{# Adjust the css variables in announcements.less if text is cut-off or wraps weirdly. #}
+<div class="site-announcement">
+  <a class="strong" href="https://blog.thunderbird.net" target="_blank">
+    {% trans trimmed %}
+      Thunderbird Monthly releases are now the default download. Click to learn more
+    {% endtrans %}
+  </a>
+</div>

--- a/sites/www.thunderbird.net/includes/announcement.html
+++ b/sites/www.thunderbird.net/includes/announcement.html
@@ -1,6 +1,6 @@
 {# Adjust the css variables in announcements.less if text is cut-off or wraps weirdly. #}
 <div class="site-announcement">
-  <a class="strong" href="https://blog.thunderbird.net" target="_blank">
+  <a class="strong" href="https://blog.thunderbird.net/2025/02/thunderbird-desktop-release-channel-default-download/" target="_blank">
     {% trans trimmed %}
       Thunderbird Monthly releases are now the default download. Click to learn more
     {% endtrans %}

--- a/sites/www.thunderbird.net/includes/base/page.html
+++ b/sites/www.thunderbird.net/includes/base/page.html
@@ -4,11 +4,11 @@
 
 {% extends "includes/base/base.html" %}
 
-{# Uncomment this to enable the site-wide announcement!
-  {% block site_header_unwrapped %}
-  {% include 'includes/announcement.html' %}
-  {% endblock %}
-#}
+{% if settings.SITE_ANNOUNCEMENT %}
+{% block site_header_unwrapped %}
+{% include 'includes/announcement.html' %}
+{% endblock %}
+{% endif %}
 
 {% block site_nav %}
 <nav class="site-nav">


### PR DESCRIPTION
Fixes #769 

Note: This currently applies to all pages, we can limit it to just home though. This also probably won't be merged until March 5th. 

cc @inattee for any copy edits / blog posts
cc @coreycb for sign-off

### Screenshots
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/1d467e34-66bb-4e66-b1ac-a596e4856e88" />
<img width="416" alt="image" src="https://github.com/user-attachments/assets/26411a70-f2cc-45aa-b4ce-8de016ebbd0b" />
