### PR TITLE
Fix utm tags for donation appeals (Fixes #795)

### DIFF
--- a/assets/js/common/donation-notice.js
+++ b/assets/js/common/donation-notice.js
@@ -60,6 +60,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Conditions for the countdown
   const donationButtons = document.querySelectorAll('[data-donate-btn]');
   for (const donationButton of donationButtons) {
+    // Any donation button that redirects should be skipped as that's not where the modal will show up.
+    if ('dontShowDonationNotice' in donationButton.dataset) {
+      continue;
+    }
     donationButton.addEventListener('click', () => {
       startDonationNoticeCountdown();
     });

--- a/assets/js/common/donations.js
+++ b/assets/js/common/donations.js
@@ -65,17 +65,21 @@ if (typeof Mozilla === 'undefined') {
         }
 
         const searchParams = new URLSearchParams(window.location.search);
-        const utmSourceNewsletter = 'newsletter';
-        const utmSource = searchParams.get('utm_source');
 
         // If a user clicks on a donate button, track the donate link click goal
         const donateButtons = document.querySelectorAll('[data-donate-btn]');
         donateButtons.forEach(function(element) {
             // Correct the utmSource
-            if (utmSource === utmSourceNewsletter) {
+            for (const [key, value] of searchParams.entries()) {
+                if (!key.startsWith('utm_')) {
+                    continue;
+                }
+
                 const href = new URL(element.href);
+
                 // Adjust the utm source to newsletter
-                href.searchParams.set('utm_source', utmSourceNewsletter);
+                href.searchParams.set(key, value);
+
                 // Set the new href
                 element.href = href.toString();
             }
@@ -209,5 +213,5 @@ if (typeof Mozilla === 'undefined') {
     }
 
     window.Mozilla.Donation = Donation;
-    Donation.Init();
+    window.addEventListener('load', () => Donation.Init());
 })();

--- a/sites/updates.thunderbird.net/includes/macros/donate-button.html
+++ b/sites/updates.thunderbird.net/includes/macros/donate-button.html
@@ -1,5 +1,5 @@
-{% macro donate_button(form_id=settings.FRU_FORM_IDS['support'], content='cta', source='thunderbird-client', campaign='appeal', base_url=None) %}
-<a href="{{ donate_url(content=content, campaign=campaign, source=source, form_id=form_id, base_url=base_url) }}" class="donate-banner" {% if base_url != None %}target="_blank"{% endif %} data-donate-btn>
+{% macro donate_button(form_id=settings.FRU_FORM_IDS['support'], content='cta', source='thunderbird-client', campaign='appeal', base_url=None, disable_notice=False) %}
+<a href="{{ donate_url(content=content, campaign=campaign, source=source, form_id=form_id, base_url=base_url) }}" class="donate-banner" {% if base_url != None %}target="_blank"{% endif %} data-donate-btn {% if disable_notice %}data-dont-show-donation-notice{% endif %}>
   <div id="donate-banner-left">
     {{ _('Click here to <b>Donate!</b>') }}
   </div>

--- a/sites/updates.thunderbird.net/thunderbird/128.0/apr25/donate/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/128.0/apr25/donate/index.html
@@ -11,6 +11,9 @@
 {% set fru_form_id = 'apr25' %}
 {% set utm_campaign = 'apr25_appeal' %}
 {% set donation_base_url = None %}
+{# We want to show the redirect notice here as this is where the modal will actually open up. #}
+{% set disable_donation_notice_banner = False %}
+
 
 {# Just include previous page instead of duplicating it all #}
 {% extends "thunderbird/128.0/apr25/index.html" %}

--- a/sites/updates.thunderbird.net/thunderbird/128.0/apr25/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/128.0/apr25/index.html
@@ -15,6 +15,8 @@
 {% set utm_campaign = utm_campaign|default('apr25_appeal') %}
 {% set utm_source = utm_source|default('thunderbird-client') %}
 {% set donation_base_url = donation_base_url|default(url('updates.128.appeal.apr25.donate')) %}
+{# Disable the donation banner on this redirect page, we set this to false in the actual donation page. #}
+{% set disable_donation_notice_banner = disable_donation_notice_banner|default(True) %}
 
 {% extends "includes/base/base.html" %}
 {% from 'includes/macros/donate-button.html' import donate_button with context %}
@@ -40,7 +42,7 @@
 {% endblock %}
 {% block content %}
   <section id="donate-button-container">
-    {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, base_url=donation_base_url) }}
+    {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, base_url=donation_base_url, disable_notice=disable_donation_notice_banner) }}
   </section>
   <section id="appeal-body">
     <div class="letter-container font-xl">


### PR DESCRIPTION
This will allow us to forward utm tags in the url to FRU. It was already setup for a newsletter key so I took off that limitation and expanded it to any utm_ param. 

Also fixes an issue where the donation notice banner (Hey you're blocking our donation platform msg) would show up on the in-tab page where the donation button redirects you to your browser. 