### PR TITLE
Add draft of instructions - how to add staff member to about us page

### DIFF
--- a/docs/updating-the-about-us-page.md
+++ b/docs/updating-the-about-us-page.md
@@ -11,26 +11,27 @@ To add a new staff member, you only need to:
 
 ### Headshots
 
-When exporting a staff member's headshot from a photo editing tool, make sure to create two versions: one at 1x resolution and another at 2x resolution.
+You can automatically generate cropped and compressed headshot images using the `tools/crop_staff_list.py` script.
 
-Follow these naming convention:
-
-- 1x: `roc.png`
-- 2x: `roc-high-res.png`
-
-Note: The high resolution naming convention deviates from the industry standard "@2x".
-
-Save both to `media/img/thunderbird/staff/`.
-
-#### Generating compressed images
-
-From the root of the `thunderbird-website` repo, create compressed versions of the images with the following command:
+To use it, make sure you've installed the image manipulation dependencies:
 
 ```bash
-python tools/compress_assets.py -r -o media/img/thunderbird/staff/
+pip install -r requirements-image.txt
 ```
 
-This will search recursively (`-r`) and overwrite (`-o`) previously compressed files.
+Add each new staff member's photo to `media/img/thunderbird/staff/uncropped/`. (This directory is gitignored.)
+
+Follow this file naming convention: `<whatever> - <First Name> <Last Name>.whatever-extension`
+(e.g. 97147377 - Melissa Autumn.jpg)
+
+As necessary, specify origin points for cropping by addding `[Left|Center|Right,Top|Center|Bottom]` to the file name. (e.g. `97147377 - Melissa Autumn[Left,Bottom].jpg`.)
+
+Then:
+
+```bash
+cd tools
+python ./crop_staff_list.py
+```
 
 ### Markup
 

--- a/docs/updating-the-about-us-page.md
+++ b/docs/updating-the-about-us-page.md
@@ -46,3 +46,13 @@ Add the new staff member using the `job_block` macro:
 ```
 
 This macro produces the appropriate markup, including the `<picture>` element.
+
+#### Specifying optional attributes
+
+You can also pass optional attributes to `high_res_img`:
+
+```jinja
+ {{ job_block(_('Staff Software Engineer, Desktop'), 'Ben Campbell', high_res_img('thunderbird/staff/ben_campbell.png', scale='2x', optional_attributes={'class': 'pixel'})) }}
+```
+
+This particular `class` ensures the image scales using nearest neighbour scaling instead of bilinear.

--- a/docs/updating-the-about-us-page.md
+++ b/docs/updating-the-about-us-page.md
@@ -1,0 +1,47 @@
+# Updating the About Us Page
+
+## Adding a new staff member
+
+The list of staff members can be found at [/about](https://www.thunderbird.net/en-US/about/) on the website.
+
+To add a new staff member, you only need to:
+
+- add the headshot image files
+- update the markup in the About Us template
+
+### Headshots
+
+When exporting a staff member's headshot from a photo editing tool, make sure to create two versions: one at 1x resolution and another at 2x resolution.
+
+Follow these naming convention:
+
+- 1x: `roc.png`
+- 2x: `roc-high-res.png`
+
+Note: The high resolution naming convention deviates from the industry standard "@2x".
+
+Save both to `media/img/thunderbird/staff/`.
+
+#### Generating compressed images
+
+From the root of the `thunderbird-website` repo, create compressed versions of the images with the following command:
+
+```bash
+python tools/compress_assets.py -r -o media/img/thunderbird/staff/
+```
+
+This will search recursively (`-r`) and overwrite (`-o`) previously compressed files.
+
+### Markup
+
+Edit the file `sites/www.thunderbird.net/about/index.html`
+
+Find the appropriate section
+
+Add the new staff member using the `job_block` macro:
+
+```jinja
+{{ job_block(_('Sr. Software Engineer, Desktop Engineering'), 'Roc', high_res_img('thunderbird/staff/roc.png', scale='2x', alt_formats=('webp',))) }}
+```
+
+This macro produces the appropriate markup, including the `<picture>` element.


### PR DESCRIPTION
Closes #799 

Adds a new page to `/docs` with instructions on how to add a staff member to the About Us page.