### PR TITLE
Fixup product_details 128esr not being major

### DIFF
--- a/product_details.py
+++ b/product_details.py
@@ -212,8 +212,8 @@ class ThunderbirdDetails():
 
         Quirks:
         - 38.0.1 starts with a point release and is added twice, once as a major and second as a stability release.
-        - 115 releases are patched up to be ESR builds.
-        - non-esr builds post 115 are ignored.
+        - 115 releases are patched up to be ESR builds, non-esr builds post 115 are ignored.
+        - 128.0esr has changed from esr to major, but list of majors has no 128 entry.
         """
         releases = {}
 
@@ -230,9 +230,11 @@ class ThunderbirdDetails():
 
         def needs_esr_fixup(version_ints: list[int]):
             """115.10.2 up until 128.0esr are mislabelled and should be esr builds"""
+            if version_ints[0] == 128:
+                return True
+
             if version_ints[0] != 115:
                 return False
-
             # If >=115.11
             if version_ints[1] >= 11:
                 return True

--- a/product_details.py
+++ b/product_details.py
@@ -229,7 +229,7 @@ class ThunderbirdDetails():
             return False
 
         def needs_esr_fixup(version_ints: list[int]):
-            """115.10.2 up until 128.0esr are mislabelled and should be esr builds"""
+            """115.10.2 to 128.0esr are mislabelled and should be esr builds"""
             if version_ints[0] == 128:
                 return True
 


### PR DESCRIPTION
Fixes #807

At https://github.com/mozilla-releng/product-details/commit/eb4828d4640095484227d88863d316f6e533d320#r156969608 the 128esr became major, but there's no 128* entry in major listing.

Not having major = not being shown. This adds it to esr fixup, to treat it as before.