### PR TITLE
Fix donate layout spacing

### DIFF
--- a/assets/less/pages/donations.less
+++ b/assets/less/pages/donations.less
@@ -14,6 +14,7 @@
     flex-direction: row;
     gap: 2rem;
     margin: auto;
+    padding-inline: 2rem;
 
     @media (max-width: @lg) {
       flex-direction: column;

--- a/assets/less/pages/donations.less
+++ b/assets/less/pages/donations.less
@@ -15,6 +15,7 @@
     gap: 2rem;
     margin: auto;
     padding-inline: 2rem;
+    width: auto;
 
     @media (max-width: @lg) {
       flex-direction: column;

--- a/assets/less/pages/donations.less
+++ b/assets/less/pages/donations.less
@@ -41,7 +41,7 @@
       justify-content: center;
       align-items: center;
       text-align: center;
-      min-width: 50%;
+      min-width: 45%;
       min-height: 480px;
 
 


### PR DESCRIPTION
Resolves #789

The columns were spaced too tightly, ending up with >100% width given the gutters and leaving no room around the iframe et al., effectively pushing the content to the viewport on one side, and overflowing with scrollbars on the other.

This adds some content padding like columns elsewhere, stops forcing them to fill maximum of the space available, and shrinks the size allowed for the embedded form (as it can't use more space than it's designed for, only growing to a certain size and not beyond, so anything around 40% would suffice here, the rest is just wasted whitespace) — to make the layout fit better within the viewport, while not making any of the content smaller: FRU width remains the same, line length and the text content remains formatted identically, just the spacing is moved more towards the page edges instead of in between the columns.