### PR TITLE
Replace outdated changelog link for mobile downloads

### DIFF
--- a/sites/www.thunderbird.net/thunderbird/all/index.html
+++ b/sites/www.thunderbird.net/thunderbird/all/index.html
@@ -202,7 +202,7 @@
                 <a class="small-link dotted" href="https://github.com/thunderbird/thunderbird-android/wiki/ReleaseNotes#minimum-android-version-compatibility">{{ _('System Requirements') }}</a>
               </li>
               <li>
-                <a class="small-link dotted" href="https://github.com/thunderbird/thunderbird-android/wiki/ReleaseNotes#change-logs">{{ _('Release Notes') }}</a>
+                <a class="small-link dotted" href="https://github.com/thunderbird/thunderbird-android/releases?q=prerelease:false">{{ _('Release Notes') }}</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Resolves #825

Until processing of mobile releases is added here, this is an interim change to point to TfA GH Releases instead of the superseded wiki.