### PR TITLE
Add underlines to major versions in releases

### DIFF
--- a/assets/less/pages/releases.less
+++ b/assets/less/pages/releases.less
@@ -26,6 +26,15 @@
     min-width: 15%;
     margin-top: 0;
     text-align: left;
+
+    a {
+      text-decoration-color: var(--bg);
+      text-decoration-thickness: 1px;
+      text-underline-offset: 0.2em;
+      &:hover {
+        text-decoration-color: var(--accent);
+      }
+    }
   }
 
   .release-minors {


### PR DESCRIPTION
Resolves #826

The fancy heading style makes the default link decoration transparent as a byproduct. Shouldn't be an issue generally, but in the release list it could look like the major versions are missing, so this adds some preexisting subtle affordance (from transparent to matching background enables it to acquire some shadows et al. for light decoration) to imply the headings are actual links to that versions.