### PR TITLE
WIP: initial poc of switching to holidays python library

### DIFF
--- a/build-site.py
+++ b/build-site.py
@@ -12,6 +12,7 @@ import settings
 from datetime import date
 
 from calgen.providers.CalendarificProvider import CalendarificProvider
+from calgen.providers.VacanzaHolidaysProvider import VacanzaHolidaysProvider
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--enus', help='Only build the en-US language.', action='store_true')
@@ -66,7 +67,8 @@ elif args.buildcalendars:
     except KeyError:
         sys.exit("No `CALENDARIFIC_API_KEY` defined.")
 
-    build_calendar.build_calendars(CalendarificProvider({'api_key': api_key}), calendar_locales)
+    # build_calendar.build_calendars(CalendarificProvider({'api_key': api_key}), calendar_locales)
+    build_calendar.build_calendars(VacanzaHolidaysProvider({}), calendar_locales)
 elif args.downloadlegal:
     print("Downloading legal documents")
     legal = builder.Legal(settings.WEBSITE_PATH)

--- a/build_calendar.py
+++ b/build_calendar.py
@@ -107,8 +107,8 @@ def build_calendars(provider: Provider, locales: dict):
         for country_name, language_code in country_info_list:
 
             # Wait 1 second due to free api restrictions
-            if is_free_tier:
-                time.sleep(1)
+            # if is_free_tier:
+            #     time.sleep(1)
 
             ical = build_ical(provider, locale, language_code, years_to_generate)
 

--- a/calgen/models/Calendar.py
+++ b/calgen/models/Calendar.py
@@ -47,8 +47,8 @@ class Calendar(object):
         data = {
             'uid': self.unique_id,
             'last-modified': datetime.now(),
-            'dtstart': self.iso_date.date(),
-            'dtend': self.iso_date.date() + timedelta(days=1),
+            'dtstart': self.iso_date,
+            'dtend': self.iso_date + timedelta(days=1),
             'summary': self.name,
             'description': self.description,
             'dtstamp': datetime.now(),

--- a/calgen/providers/VacanzaHolidaysProvider.py
+++ b/calgen/providers/VacanzaHolidaysProvider.py
@@ -1,0 +1,55 @@
+from calgen.models.Calendar import Calendar, CalendarTypes
+
+from calgen.providers.Provider import Provider
+
+import holidays
+
+
+class VacanzaHolidaysProvider(Provider):
+    def __init__(self, auth_options: dict):
+        super().__init__("VacanzaHolidays", {})
+
+    def query(self, country: str, year: int, additional_options: dict) -> list:
+        if country == "US":
+            print(country, year, additional_options)
+        """Queries Calendarific, will return either the response data, or None if the api returns garbage data."""
+        if country is None:
+            raise RuntimeError("Country parameter is missing")
+        if year is None:
+            raise RuntimeError("Year parameter is missing")
+
+        language = additional_options.get("language")
+
+
+        calendar_type = additional_options.get("calendar_type")
+        language = additional_options.get("language")
+
+        if calendar_type is None:
+            raise RuntimeError("Calendar Type additional option is missing")
+
+
+        try:
+            cal = holidays.country_holidays(country, years=year, language=language)
+        except NotImplementedError:
+            print(f"no calendar available for {country} with language {language}")
+            return []
+
+        return cal.items()
+
+    def build(self, country: str, year: int, additional_options: dict):
+        """Queries Calendarific, builds, and returns a list of Calendarific models from the queried data."""
+        holidays = self.query(country, year, additional_options)
+
+        holidayModels: list[Calendar] = []
+        for d, n in holidays:
+            c = Calendar()
+            c.unique_id = hash(str(d) + n)
+            c.year = year
+            c.iso_date = d
+            c.name = n
+            c.description = n
+            c.calendar_type = CalendarTypes.NATIONAL
+
+            holidayModels.append(c)
+
+        return holidayModels

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,4 @@ pytest~=7.3.1
 python-dateutil~=2.8.2
 packaging~=23.1
 setuptools==78.1.1
+hollidays>=0.73


### PR DESCRIPTION
This is just an initial POC of how it could look like, if we switched to the Holidays library in Python. It works fairly well, and it seems to be well maintained, with an active userbase.

The library in question https://github.com/vacanza/holidays

This PR needs a lot of cleanup. I just threw it together, to get some idea of how everything works together. But this should be fairly doable? However, the calendar will look vastly different from the old one, and there are a lot more types in this calendar (bank, government, school, etc. etc.).

This would close #753 , if it gets implemented fully.