### PR TITLE
Simplify donation form animation

### DIFF
--- a/assets/less/pages/donations.less
+++ b/assets/less/pages/donations.less
@@ -51,7 +51,6 @@
         // Fade in so it's not super jarring...
         animation-duration: 2s;
         animation-name: fade-in;
-        transition: none .5s ease-in;
 
         border: var(--border-size) solid var(--border-color);
         border-radius: var(--border-radius);


### PR DESCRIPTION
Fixes #830

Animates only the node appearing in DOM, not any of the other values like dimensions or borders etc. to simplify the overall fade in of the widget.