### PR TITLE
Add an exception in download.js / download dropdown for Japanese mac builds. (Fixes #835)

### DIFF
--- a/assets/js/common/download.js
+++ b/assets/js/common/download.js
@@ -228,7 +228,10 @@ if (typeof Mozilla === 'undefined') {
     }
 
     // Only options that pass "has_localized_download" are allowed to be selected which makes this safe!
-    if (locale !== 'en-US') {
+    // Note: The Japanese mac version is an exception here.
+    if (locale === 'ja' && installer === 'osx') {
+      downloadLink = downloadLink.replace('en-US', 'ja-JP-mac');
+    } else if (locale !== 'en-US') {
       downloadLink = downloadLink.replace('en-US', locale);
     }
 


### PR DESCRIPTION
Ideally the fix would be to unify the two download functions. But this should work in the interm. 

See https://github.com/thunderbird/thunderbird-website/issues/837 for a better solution.