### PR TITLE
Expose download buttons to l10n

### DIFF
--- a/sites/www.thunderbird.net/includes/base/nav.html
+++ b/sites/www.thunderbird.net/includes/base/nav.html
@@ -80,8 +80,8 @@
   </li>
   <li class="nav-entry no-border no-mobile nav-button-fix">
     <div class="header-download">
-      <a href="{{ url('thunderbird.latest.all') }}" class="btn btn-no-bg" aria-label="{{ _('Downloads') }}" title="{{ _('Find the latest version of Thunderbird.') }}">
-        Downloads
+      <a href="{{ url('thunderbird.latest.all') }}" class="btn btn-no-bg" title="{{ _('Find the latest version of Thunderbird.') }}">
+        {{_('Downloads')}}
       </a>
     </div>
   </li>

--- a/sites/www.thunderbird.net/includes/base/page.html
+++ b/sites/www.thunderbird.net/includes/base/page.html
@@ -47,7 +47,7 @@
 
   {% block breadcrumbs %}
   <div class="breadcrumbs" aria-hidden="true">
-    Home > {% block category %}{% endblock %} >
+    {{_('Home')}} > {% block category %}{% endblock %} >
   </div>
   {% endblock %}
 

--- a/sites/www.thunderbird.net/includes/download/macros/download-desktop.html
+++ b/sites/www.thunderbird.net/includes/download/macros/download-desktop.html
@@ -20,7 +20,7 @@
               {{ plat.os_arch_pretty or plat.os_pretty }}
             </span>
             <span class="js-label">
-              {{ 'Download' }}
+              {{ _('Download') }}
             </span>
           </a>
         </div>


### PR DESCRIPTION
Fix #851

Main download CTA and desktop menu button translated with gettext, terms already existing.

(Accessibility label removed now when the implicit content is the same.)