### PR TITLE
Expose smart CTA "other" downloads to l10n

### DIFF
--- a/sites/www.thunderbird.net/includes/download/macros/download-smart.html
+++ b/sites/www.thunderbird.net/includes/download/macros/download-smart.html
@@ -27,7 +27,7 @@ Macros:
     </div>
     <div class="download-button" data-download-platform="other">
       <a href="{{ url('thunderbird.latest.all') }}" class="btn btn-download btn-slim {{ btn_class }}">
-        Downloads
+        {{ _('Downloads') }}
       </a>
     </div>
   {% elif force_platform == 'android' %}
@@ -40,7 +40,7 @@ Macros:
     </div>
     <div class="download-button" data-download-platform="other">
       <a href="{{ url('thunderbird.latest.all') }}" class="btn btn-download btn-slim {{ btn_class }}">
-        Downloads
+        {{ _('Downloads') }}
       </a>
     </div>
   {% endif %}


### PR DESCRIPTION
See #851 followup to #852

Also adding smart slim CTA `"other"` downloads to gettext, terms already existing.