### PR TITLE
Restore footer on thunderbird.net

### DIFF
--- a/sites/www.thunderbird.net/includes/base/base.html
+++ b/sites/www.thunderbird.net/includes/base/base.html
@@ -63,10 +63,9 @@
     {% block site_header_unwrapped %}{% endblock %}
 
     {% block site_nav %}{% endblock %}
+
     {% block site_header %}
     {% endblock %}
-
-
 
     <main>
       {% block pre_content %}{% endblock %}
@@ -77,7 +76,7 @@
     </main>
 
     {% block site_footer %}
-      {% include 'includes/base/shared-footer.html' %}
+        {% include 'includes/base/footer.html' %}
     {% endblock %}
 
     {% block additional_site_js %}{% endblock %}


### PR DESCRIPTION
Addressing issue raised here: https://github.com/thunderbird/thunderbird-website/pull/943#issuecomment-3424667817

This PR restores the original footer for www.thunderbird.net.