### PR TITLE
Add source mime type to picture high res helper

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -184,8 +184,8 @@ def high_res_img(ctx, url, optional_attributes=None, scale='1.5x', alt_formats=(
             alt_high_res_url = f"{url_high_res.rsplit('.', maxsplit=1)[0]}.{alt_format}"
 
             tags.append(
-                '<source src="{url}" srcset="{url_high_res} {scale}"/>'.format(
-                    url=alt_url, url_high_res=alt_high_res_url, scale=scale
+                '<source src="{url}" srcset="{url_high_res} {scale}" type="image/{type}">'.format(
+                    url=alt_url, url_high_res=alt_high_res_url, scale=scale, type=alt_format
                 )
             )
 


### PR DESCRIPTION
Resolves #842

This fixes AVIF/WebP compatibility issues in older browsers.

(NB: The simplified idea is to take the alt format as currently provided, used as file extension, and blindly invent "image/[format]" type attribute. This currently works for both "webp" and "avif" types, and if a future "quux" format with ".quux" extension is added it would work too if its mime type would be "image/quux" — however would produce nonsense if its mime was supposed to be "application/quux" or "image/quux+xml", or its extension would differ, e.g. ".quu"… — That said, e.g. "svg" would produce a dubious mime type here; but a vector should not be really used in the high res helper per se anyways…)