### PR TITLE
Add build+test CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
       run: |
         npm install -g less
         pip install -r requirements-dev.txt
-        git clone https://github.com/thunderbird/thunderbird-notes.git libs/thunderbird_notes
-        git clone -b production https://github.com/mozilla-releng/product-details.git libs/product-details
+        git clone --depth 1 https://github.com/thunderbird/thunderbird-notes.git libs/thunderbird_notes
+        git clone --depth 1 -b production https://github.com/mozilla-releng/product-details.git libs/product-details
     - name: Build site (just on darwin)
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
This GitHub Actions workflow runs a matrix of a few select Python and Node versions on several platforms/archs to verify sites build and tests run for PRs and master pushes; with visibility into deprecations and incompatibilities for future versions.

Resolves #863

👓 demo/preview: [`@janbrasna/thunderbird-website` /actions/runs/18867825525](https://github.com/janbrasna/thunderbird-website/actions/runs/18867825525/job/53838925997)