### PR TITLE
Disable the "donation platform is blocked" notice on redirect pages

### DIFF
--- a/sites/updates.thunderbird.net/thunderbird/140.0/nov25a/donate/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/nov25a/donate/index.html
@@ -12,6 +12,8 @@
 {% set utm_content = 'cta_a' %}
 {% set utm_campaign = 'nov25_appeal' %}
 {% set donation_base_url = None %}
+{# We want to show the redirect notice here as this is where the modal will actually open up. #}
+{% set disable_donation_blocked_notice = False %}
 
 {# Just include previous page instead of duplicating it all #}
 {% extends "thunderbird/140.0/nov25a/index.html" %}

--- a/sites/updates.thunderbird.net/thunderbird/140.0/nov25a/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/nov25a/index.html
@@ -15,6 +15,8 @@
 {% set utm_campaign = utm_campaign|default('nov25_appeal') %}
 {% set utm_source = utm_source|default('in_app') %}
 {% set donation_base_url = donation_base_url|default(url('updates.140.appeal.nov25a.donate')) %}
+{# Disable the donation banner on this redirect page, we set this to false in the actual donation page. #}
+{% set disable_donation_blocked_notice = disable_donation_blocked_notice|default(True) %}
 
 {% extends "includes/base/base.html" %}
 {% from 'includes/macros/donate-button.html' import donate_button with context %}
@@ -33,7 +35,7 @@
 
     <div id="appeal-letter" class="letter-container font-xl">
       <section id="donate-button-container">
-        {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, content=utm_content, base_url=donation_base_url) }}
+        {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, content=utm_content, base_url=donation_base_url, disable_donation_blocked_notice=disable_donation_blocked_notice) }}
       </section>
       <div id="letter-contents">
         <p>

--- a/sites/updates.thunderbird.net/thunderbird/140.0/nov25b/donate/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/nov25b/donate/index.html
@@ -12,6 +12,8 @@
 {% set utm_content = 'cta_b' %}
 {% set utm_campaign = 'nov25_appeal' %}
 {% set donation_base_url = None %}
+{# We want to show the redirect notice here as this is where the modal will actually open up. #}
+{% set disable_donation_blocked_notice = False %}
 
 {# Just include previous page instead of duplicating it all #}
 {% extends "thunderbird/140.0/nov25b/index.html" %}

--- a/sites/updates.thunderbird.net/thunderbird/140.0/nov25b/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/nov25b/index.html
@@ -15,6 +15,8 @@
 {% set utm_campaign = utm_campaign|default('nov25_appeal') %}
 {% set utm_source = utm_source|default('in_app') %}
 {% set donation_base_url = donation_base_url|default(url('updates.140.appeal.nov25b.donate')) %}
+{# Disable the donation banner on this redirect page, we set this to false in the actual donation page. #}
+{% set disable_donation_blocked_notice = disable_donation_blocked_notice|default(True) %}
 
 {% extends "includes/base/base.html" %}
 {% from 'includes/macros/donate-button.html' import donate_button with context %}
@@ -42,7 +44,7 @@
 {% endblock %}
 {% block content %}
   <section id="donate-button-container">
-    {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, content=utm_content, base_url=donation_base_url) }}
+    {{ donate_button(form_id=fru_form_id, campaign=utm_campaign, source=utm_source, content=utm_content, base_url=donation_base_url, disable_donation_blocked_notice=disable_donation_blocked_notice) }}
   </section>
   <section id="appeal-body">
     <div class="letter-container font-xl">


### PR DESCRIPTION
Ah forgot about this one, there was a period where FRU was blocked by ublock or a similar ad blocking plugin. We added a notice which we destroy once FRU checkout is loaded. However we need a flag to disable it on the redirect pages otherwise you'd get the notice when you went back to Thunderbird like so:

<img width="2283" height="1077" alt="image" src="https://github.com/user-attachments/assets/d7eb0811-ff75-4c07-855d-13f4093e3d79" />

This should fix that up.