### PR TITLE
Fix tb.pro nav for Safari at desktop widths

### DIFF
--- a/assets/less/tbpro/base.less
+++ b/assets/less/tbpro/base.less
@@ -145,6 +145,8 @@ body {
                 @media (min-width: @lg) {
                     align-items: center;
                     display: grid;
+
+                    // Take up the entire width.
                     grid-column: 1 / -1;
 
                     // Use auto for the middle three columns so that they


### PR DESCRIPTION
Closes #1025

Fixes nav bar for desktop on tb.pro marketing page
* Remove nested subgrid
* Manually adjust margins for home, product, and sign in links