### PR TITLE
Fix the SyntaxWarning: invalid escape sequence '\.'

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -345,9 +345,9 @@ class Site(object):
         redirect_rules = (
             'RewriteEngine On\n'
             'RewriteCond %{REQUEST_FILENAME} !-d\n'
-            'RewriteRule ^(115\.[^/]+)esr/(.*)$ /thunderbird/$1/$2 [R,L]\n'
+            'RewriteRule ^(115\\.[^/]+)esr/(.*)$ /thunderbird/$1/$2 [R,L]\n'
             'RewriteCond %{REQUEST_FILENAME} !-d\n'
-            'RewriteRule ^(115\.[^/]+)/(.*)$ /thunderbird/$1esr/$2 [R,L]\n'
+            'RewriteRule ^(115\\.[^/]+)/(.*)$ /thunderbird/$1esr/$2 [R,L]\n'
         )
         write_htaccess_custom(thunderbird_root, redirect_rules)
 


### PR DESCRIPTION
Regardless of this fix, the build generates the correct `.htaccess` file.  
This commit just updates the syntax.

Closes [#951](https://github.com/thunderbird/thunderbird-website/issues/951)