### PR TITLE
Fix height difference of tab nav bar across tb.net and tb.pro

### DIFF
--- a/assets/less/tbpro/base.less
+++ b/assets/less/tbpro/base.less
@@ -55,8 +55,7 @@ body {
     padding-top: @space-16;
 
     @media (min-width: @lg) {
-        padding-top: @space-24;
-        margin-top: -0.25rem;
+        padding-top: 1.25rem;
     }
 
     #site-header-nav {


### PR DESCRIPTION

Fixes the 4px difference in height of tab-navigation-bar between www and tb.pro

Details:
* tb.pro styling used a negative margin to match the design
* The negative margin caused 4px of the tab-navigation-bar to be hidden
* Fixed by adjusting the padding and removing the negative margin