### PR TITLE
For tablet width for Dec25-1 appeal: use desktop image, positioned relative to width

### DIFF
--- a/assets/less/appeals/dec25-1.less
+++ b/assets/less/appeals/dec25-1.less
@@ -66,7 +66,6 @@ html, body {
             url('/media/img/thunderbird/appeal/dec25-1/appeal-Dec3-wallpaper-XS-high-res.webp') 2x
         );
 
-
         background-color: var(--background-dark-blue);
         background-position: top center;
         background-repeat: no-repeat;
@@ -77,8 +76,8 @@ html, body {
         padding-bottom: 5rem;
         min-width: 23.438rem;
 
-
-        @media (min-width: @lg) {
+        // Use desktop image sooner and position background image relative to viewport width.
+        @media (min-width: @sm) {
             // Regular DPI fallback
             background-image: url('/media/img/thunderbird/appeal/dec25-1/appeal-Dec3-wallpaper-XL.webp');
 
@@ -92,6 +91,10 @@ html, body {
                 url('/media/img/thunderbird/appeal/dec25-1/appeal-Dec3-wallpaper-XL-high-res.webp') 2x
             );
 
+            background-position: center calc(0% - 30vw);
+        }
+
+        @media (min-width: @lg) {
             background-position: left top;
             background-repeat: no-repeat;
             background-size: auto 100%;


### PR DESCRIPTION

Addresses situation where a user opens Thunderbird in a (roughly) tablet-width window:
- Dec25-1a or Dec25-1b appeal is shown
- background image is pixelated
- background image is positioned such that the birds are not visible