### PR TITLE
Dec25-2 appeal: uppercase title, tweak button styles

### DIFF
--- a/assets/less/appeals/dec25-2.less
+++ b/assets/less/appeals/dec25-2.less
@@ -225,7 +225,7 @@ html, body {
                     #decoration {
                         left: -85px;
                         @media (min-width: @md) {
-                            left: 25px;
+                            left: -35px;
                         }
                     }
                 }
@@ -233,7 +233,7 @@ html, body {
                 .donate-banner::after {
                     left: -263px;
                     @media (min-width: @md) {
-                        left: -163px;
+                        left: -213px;
                     }
                 }
 
@@ -241,7 +241,7 @@ html, body {
                     font-size: 0.8rem;
                     font-weight: 600;
                     line-height: 1.3;
-
+                    width: 33%
                     b {
                         font-size: 1.5rem;
                         font-weight: 600;
@@ -249,16 +249,19 @@ html, body {
                     }
 
                     @media (min-width: @md) {
-                        font-size: 1.5rem;
+                        flex: 0 1 auto;
+                        font-size: 1rem;
                         b {
-                            font-size: 2.5rem;
+                            font-size: 2.0rem;
                         }
                     }
                 }
 
                 #donate-banner-right {
+                    color: rgb(69, 10, 10);
                     display: block;
                     font-weight: 400;
+                    text-shadow: none;
                     b {
                         display: block;
                         font-weight: 600;

--- a/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2a/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2a/index.html
@@ -28,7 +28,7 @@
 
 {% block content %}
   <section id="appeal-body">
-    <h1 id="appeal-heading" class="with-lowercase" aria-label="{{ _('Thunderbird Needs You') }}">
+    <h1 id="appeal-heading" aria-label="{{ _('Thunderbird Needs You') }}">
       {{ _('Thunderbird <span>Needs You</span>') }}
     </h1>
 

--- a/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2b/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2b/index.html
@@ -28,7 +28,7 @@
 
 {% block content %}
   <section id="appeal-body">
-    <h1 id="appeal-heading" class="with-lowercase" aria-label="{{ _('Only 3% of users support Thunderbird') }}">
+    <h1 id="appeal-heading" aria-label="{{ _('Only 3% of users support Thunderbird') }}">
       {{ _('Only 3% of users <span>SUPPORT THUNDERBIRD</span>') }}
     </h1>
 

--- a/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2c/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/140.0/dec25-2c/index.html
@@ -28,7 +28,7 @@
 
 {% block content %}
   <section id="appeal-body">
-    <h1 id="appeal-heading" class="with-lowercase" aria-label="{{ _('Only 3% of users support Thunderbird') }}">
+    <h1 id="appeal-heading" aria-label="{{ _('Only 3% of users support Thunderbird') }}">
       {{ _('Only 3% of users <span>SUPPORT THUNDERBIRD</span>') }}
     </h1>
 


### PR DESCRIPTION
This PR applies to all three versions of the appeal (A, B, and C):
* makes sure all title text is uppercase
* adjusts button styles (text sizes, placement of animated decoration)