### PR TITLE
Appeal Dec25-2: remove width constraint on donate button text

### DIFF
--- a/assets/less/appeals/dec25-2.less
+++ b/assets/less/appeals/dec25-2.less
@@ -248,7 +248,6 @@ html, body {
                     font-size: 0.8rem;
                     font-weight: 600;
                     line-height: 1.3;
-                    width: 33%;
 
                     b {
                         font-size: 1.5rem;


### PR DESCRIPTION
Removes the `width: 33%` constraint on `#donate-banner-left`, which was causing:

<img width="700" height="207" alt="image" src="https://github.com/user-attachments/assets/c356dd1c-58b3-4558-9db3-d9ddf0f7a304" />



Removing it corrects the layout:

<img width="700" height="207" alt="image" src="https://github.com/user-attachments/assets/d4621fc9-476d-4d6f-a0f8-e616e7cb06d6" />
