### PR TITLE
Fix waitlist locale redirect

### DIFF
--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -352,6 +352,7 @@ SetEnvIf X-Forwarded-Proto "^https$" HTTPS=on
   WSGIScriptAliasMatch ^/appointment[/]?$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/send[/]?$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/thundermail[/]?$ /var/www/html/start/wsgi.py
+  WSGIScriptAliasMatch ^/waitlist[/]?$ /var/www/html/start/wsgi.py
   # Bug 1862171
   Header always set X-Frame-Options "DENY"
 </VirtualHost>

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -86,6 +86,11 @@ TEST_CASES = [
 
     # tb.pro
     ("tb.pro", "/ja-JP-mac/", 302, "/ja/"),
+    ("tb.pro", "/", 302, "/en-US/"),
+    ("tb.pro", "/appointment", 302, "/en-US/appointment"),
+    ("tb.pro", "/send", 302, "/en-US/send"),
+    ("tb.pro", "/thundermail", 302, "/en-US/thundermail"),
+    ("tb.pro", "/waitlist", 302, "/en-US/waitlist"),
 ]
 
 
@@ -125,6 +130,9 @@ LOCALE_TESTS = [
     ("www.thunderbird.net", "/", "en-US", "/en-US/"),
     ("www.thunderbird.net", "/", "fr", "/fr/"),
     ("www.thunderbird.net", "/", "ja", "/ja/"),
+    ("tb.pro", "/waitlist", "en-US", "/en-US/waitlist"),
+    ("tb.pro", "/waitlist", "fr", "/fr/waitlist"),
+    ("tb.pro", "/waitlist", "ja", "/ja/waitlist"),
 ]
 
 


### PR DESCRIPTION
## Description of changes

Added a missing Apache config for the waitlist locale redirect + tests

## How to test locally

```
# Build Docker image
docker build -f docker/Dockerfile -t thunderbird-web:test .

# Run the container
docker run -d --name tb-web-test -p 8080:80 thunderbird-web:test

# Test that /waitlist redirects properly (should get 302 redirect to /en-US/waitlist)
curl -H "Host: tb.pro" -H "X-Forwarded-Proto: https" -I http://localhost:8080/waitlist

# Test with different Accept-Language headers
curl -H "Host: tb.pro" -H "X-Forwarded-Proto: https" -H "Accept-Language: fr" -I http://localhost:8080/waitlist

# Test that the localized page exists (should get 200 OK)
curl -H "Host: tb.pro" -H "X-Forwarded-Proto: https" -I http://localhost:8080/en-US/waitlist
```


## Related issues

Fixes https://github.com/thunderbird/thunderbird-website/issues/1090