### PR TITLE
Remove hostname string replacement for tab highlighting on stage

### DIFF
--- a/sites/common/includes/base/tab-navigation-bar.html
+++ b/sites/common/includes/base/tab-navigation-bar.html
@@ -7,7 +7,7 @@
 
 <script>
   const stageHosts = {{ settings.STAGE_HOSTS|tojson|safe }};
-  const currentHost = window.location.hostname.replace('www.', '');
+  const currentHost = window.location.hostname;
   const isStage = stageHosts.includes(currentHost);
 
   if (isStage) {
@@ -19,7 +19,7 @@
 
   // Set .active class accordingly.
   document.querySelectorAll('#tab-navigation-bar a').forEach(link => {
-    const linkHost = new URL(link.href).hostname.replace('www', '');
+    const linkHost = new URL(link.href).hostname;
 
     if (linkHost === currentHost) {
       link.classList.add('active');


### PR DESCRIPTION
Fixes #1097 

Tiny quality-of-life tweak when viewing the stage version of thunderbird.net:
- Fix broken hostname matching for highlighting.