### PR TITLE
Moves include for tab-navigation-bar just inside <body> on tb.net

### DIFF
--- a/sites/www.thunderbird.net/includes/base/base.html
+++ b/sites/www.thunderbird.net/includes/base/base.html
@@ -62,7 +62,7 @@
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>
     <div id="strings" {% block string_data %}{% endblock %}></div>
-
+    {% include 'includes/base/tab-navigation-bar.html' %}
     {# for headers not to be confined by #wrapper (like fx family nav) #}
     {% block site_header_unwrapped %}{% endblock %}
 

--- a/sites/www.thunderbird.net/includes/base/page.html
+++ b/sites/www.thunderbird.net/includes/base/page.html
@@ -4,8 +4,6 @@
 
 {% extends "includes/base/base.html" %}
 
-{% include 'includes/base/tab-navigation-bar.html' %}
-
 {% block site_header_unwrapped %}
 {% include 'includes/announcement.html' %}
 {% endblock %}


### PR DESCRIPTION

The include for the tab-navigation-bar on thunderbird.net was in the wrong place.

This moves the include, so that it's just inside the body tag.

Did a quick check that it renders the same.