### PR TITLE
Prefill email from querystring param

### DIFF
--- a/sites/tb.pro/includes/base/base.html
+++ b/sites/tb.pro/includes/base/base.html
@@ -68,5 +68,7 @@
     {% block additional_site_js %}{% endblock %}
 
     {% block js %}{% endblock %}
+    {% block additional_page_js %}{% endblock %}
+
   </body>
 </html>

--- a/sites/tb.pro/waitlist/index.html
+++ b/sites/tb.pro/waitlist/index.html
@@ -12,6 +12,23 @@
 <link href="{{ static('css/waitlist.css') }}" rel="stylesheet" type="text/css" />
 {% endblock %}
 
+{% block additional_page_js %}
+<script>
+  (function () {
+    // Prefill the email address if they were redirected here from
+    // the thunderbird-accounts site.
+    const urlParams = new URLSearchParams(window.location.search);
+    const emailValue = urlParams.get('email');
+
+    if (emailValue) {
+      const emailField = document.querySelector('#mce-EMAIL');
+      emailField.value = emailValue;
+    }
+  }())
+</script>
+{% endblock %}
+
+
 {% block masthead %}
 <h1>{{ _('Join the Waitlist') }}</h1>
 {% endblock %}


### PR DESCRIPTION
Closes #1112 

Requires deployment of this [tb-accounts PR](https://github.com/thunderbird/thunderbird-accounts/pull/587)

Adds some JavaScript to the wait list page that:
* checks for an `email` querystring param
* prefills the email field with that value