### PR TITLE
Changed some calendar names to represent country names

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -608,40 +608,26 @@ CALENDAR_LOCALES = {
 
 # Used to normalize filenames for calendar generation
 # This is the first part of the filename, 'Holidays' is bolted on in code.
-# So 'Belgium (Dutch)' will become 'BelgiumHoldays.ics'
+# So 'Belgium (Dutch)' will become 'BelgiumHoldaysDutch.ics'
 # If the value is a tuple, the first part is before 'Holidays' and the second part is after.
 CALENDAR_REMAP = {
-    'Algeria (French)': 'Algeria',
+    'Algeria (French)': ('Algeria', 'French'),
     'Algeria (Arabic)': ('Algeria', 'Arabic'),
-    'Belgium (Dutch)': 'Belgium',
+    'Belgium (Dutch)': ('Belgium', 'Dutch'),
     'Belgium (French)': ('Belgium', 'French'),
-    'Bulgaria': 'Bulgarian',
-    'Canada (English)': 'Canada',
+    'Canada (English)': ('Canada', 'English'),
     'Canada (French)': ('Canada', 'French'),
-    'Colombia': 'Colombian',
-    'Finland (Finnish)': 'Finland',
+    'Finland (Finnish)': ('Finland', 'Finnish'),
     'Finland (Swedish)': ('Finland', 'Swedish'),
-    'France': 'French',
-    'Germany': 'German',
-    'Hungary': 'Hungarian',
-    'Ireland (English)': 'Ireland',
+    'Ireland (English)': ('Ireland', 'English'),
     'Ireland (Irish)': ('Ireland', 'Irish'),
-    'Italy': 'Italian',
     'Kazakhstan': ('Kazakhstan', 'English'),
-    'Lithuania': 'Lithuanian',
     'Luxembourg (French)': ('Luxembourg', 'French'),
     'Luxembourg (German)': ('Luxembourg', 'German'),
-    'Netherlands (Dutch)': 'Dutch',
-    'Netherlands (English)': ('Dutch', 'English'),
-    'Netherlands (German)': ('Dutch', 'German'),
-    'Netherlands (French)': ('Dutch', 'French'),
-    'Norway': 'Norwegian',
-    'Poland': 'Polish',
-    'Slovenia': 'Slovenian',
-    'Slovakia': 'Slovak',
-    'Switzerland': 'Swiss',
-    'United Kingdom': 'UK',
-    'United States': 'US'
+    'Netherlands (Dutch)': ('Netherlands', 'Dutch'),
+    'Netherlands (English)': ('Netherlands', 'English'),
+    'Netherlands (German)': ('Netherlands', 'German'),
+    'Netherlands (French)': ('Netherlands', 'French'),
 }
 
 # Filter out specific versions for the release notes page


### PR DESCRIPTION
Corresponding issue: #884
Changed calendar names to the respective country name instead of language in settings.py.

Unfortunately, due to free tier limitation, I am not able to update all calendars.
This should be done as they currently contain holidays from 2025 - 2028 instead of from 2026 - 2029 and they seem to have been last updated in 04/2025.