### PR TITLE
Serve new autoconfig JSON file on the root path

### DIFF
--- a/docker/scripts/update-autoconfig.sh
+++ b/docker/scripts/update-autoconfig.sh
@@ -22,6 +22,10 @@ cp -R ../webroot/* $TEMP/
 source /var/www/tbservices/bin/activate
 python ../tools/convert.py -a -d $TEMP/v1.1 *
 
+# Convert.py generates a JSON file, which we want to serve on the root
+# path rather than under v1.1/.
+mv $TEMP/v1.1/generated_files.json $TEMP
+
 # Move generated files into place
 rm -rf $DEST/*
 mv $TEMP/* $DEST/


### PR DESCRIPTION
As of https://github.com/thunderbird/autoconfig/pull/180, the autoconfig deployment script generates a JSON file listing all generated configurations (`generated_files.json`). That script (`tools/convert.py` in the autoconfig repo) doesn't have knowledge of the folder hierarchy on the server once deployed, and so generates everything in a single folder.

After chatting with @Sancus, we agreed that it would be better to serve this file outside of the `v1.1/` path so we don't risk confusing existing tools that consume ISPDB, which might expect everything under `v1.1/` to be XML.