### PR TITLE
Feat/roadmaps design tweaks 20260311 1

### DIFF
--- a/assets/less/roadmaps/index.less
+++ b/assets/less/roadmaps/index.less
@@ -85,11 +85,7 @@ body {
     --hamburger-foreground-inactive: var(--color-gray-30);
     --hamburger-background-active: var(--color-white);
     --hamburger-foreground-active: var(--color-black);
-
-    &.scrolled-nav {
-        // Override the transparent white border.
-        border-color: rgba(0, 0, 0, 0.8);
-    }
+    background-color: rgba(0, 0, 0, 0.8);
 
     // From 2025-fonts.less
     .nav-links .nav-ln {
@@ -225,6 +221,7 @@ a {
       margin-top: 0;
       margin-bottom: 1rem;
       padding-left: 40px;
+      outline: 1px solid red;
     }
 
     .home {
@@ -482,9 +479,11 @@ main {
     li {
         // The rest of the content is not wrapped in a tag.
         .web-body-small();
+        font-weight: 300;
         @media (min-width: @tablet-breakpoint) {
             .web-body-default();
         }
+
         line-height: 1.075rem;
 
         background-color: var(--colour-surface-base);
@@ -517,11 +516,20 @@ main {
         strong {
             .web-title-small();
             display: block;
+
+            // Override per dev feedback
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+
             @media (min-width: @tablet-breakpoint) {
                 .web-title-medium();
 
                 // Override per Design Team
                 line-height: normal;
+
+                // Override per dev feedback
+                font-weight: 500;
+                margin-bottom: 0;
             }
         }
 
@@ -529,6 +537,9 @@ main {
         bolt-primary-button {
             justify-self: start;
             margin-top: 0.25rem;
+
+            // Anchor to bottom of card.
+            align-self: end;
         }
     }
 
@@ -697,6 +708,8 @@ main {
             .brand-headline-h2-sm();
             margin: 0;
             margin-bottom: 1.35rem;
+            display: flex;
+            gap: 0.75rem;
 
             @media (min-width: @desktop-breakpoint) {
                 position: sticky;

--- a/settings.py
+++ b/settings.py
@@ -274,6 +274,7 @@ URL_MAPPINGS = {
     'tbpro.status': 'https://status.tb.pro/',
     'tbpro.support': 'https://support.tb.pro/',
     'tbpro.ideas': 'https://ideas.tb.pro',
+    'roadmaps': 'https://roadmaps.thunderbird.net/',
     'roadmaps.home': '/',
     'roadmaps.desktop': '/desktop',
     'roadmaps.android': '/android',

--- a/sites/roadmaps.thunderbird.net/includes/base/base.html
+++ b/sites/roadmaps.thunderbird.net/includes/base/base.html
@@ -103,16 +103,6 @@
 
         // Allow page to show hamburger menu.
         document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, "js");
-
-        // From main tb website
-        const navbar = document.querySelector(".site-nav");
-        if (navbar) {
-          const navbarClass = 'scrolled-nav';
-          let navbarState = navbar.classList.contains(navbarClass);
-          navbar.classList.add(navbarClass);
-
-
-        }
       })()
     </script>
     {% block additional_site_js %}{% endblock %}

--- a/sites/roadmaps.thunderbird.net/includes/base/footer.html
+++ b/sites/roadmaps.thunderbird.net/includes/base/footer.html
@@ -25,6 +25,7 @@
           <li><a href="{{ url('thunderbird.releases.index') }}" class="dotted">{{_('Release Notes')}}</a></li>
           <li><a href="{{ url('thunderbird.enterprise') }}" class="dotted">{{ _('For Enterprises') }}</a></li>
           <li><a href="{{ url('thunderbird.calendar.holiday') }}" class="dotted">{{ _('Holiday Calendars') }}</a></li>
+          <li><a href="{{ url('roadmaps') }}" class="dotted">{{ _('Roadmaps') }}</a></li>
         </ul>
       </div>
       <div class="site-link-section">

--- a/sites/roadmaps.thunderbird.net/includes/base/page.html
+++ b/sites/roadmaps.thunderbird.net/includes/base/page.html
@@ -4,7 +4,7 @@
 {% endmacro %}
 
 {% block site_nav %}
-<nav class="site-nav scrolled-nav">
+<nav class="site-nav">
   <div class="nav-container">
     <a href="{{ url('thunderbird.index') }}" class="logo" title="{{ _('Thunderbird') }}" aria-label="{{ _('Thunderbird Logo') }}">
       {{ svg('Thunderbird_Logo') }}

--- a/sites/www.thunderbird.net/includes/base/footer.html
+++ b/sites/www.thunderbird.net/includes/base/footer.html
@@ -25,6 +25,7 @@
           <li><a href="{{ url('thunderbird.releases.index') }}" class="dotted">{{_('Release Notes')}}</a></li>
           <li><a href="{{ url('thunderbird.enterprise') }}" class="dotted">{{ _('For Enterprises') }}</a></li>
           <li><a href="{{ url('thunderbird.calendar.holiday') }}" class="dotted">{{ _('Holiday Calendars') }}</a></li>
+          <li><a href="{{ url('roadmaps') }}" class="dotted">{{ _('Roadmaps') }}</a></li>
         </ul>
       </div>
       <div class="site-link-section">


### PR DESCRIPTION
Misc updates to styles, per developer feedback:

* make tab-bar-navigation highlight "Thunderbird" when on roadmaps site
* header nav background color set to black
* set font-weight to 500 for landing page card titles
* "View roadmap" button now anchors to bottom
* Bold font-weight for footer h4
* Add 4px gap between landing page card title and copy
* Fixes vertical alignment of phosphoricons

Not changing the following:

* gap between header and content of card on product pages (could not reproduce)
* vertical alignment of TB logo and main heading (matches www, leaving as-is)