### PR TITLE
Adjust roadmap styles per design QA

### DIFF
--- a/assets/less/roadmaps/index.less
+++ b/assets/less/roadmaps/index.less
@@ -510,7 +510,6 @@ main {
             display: block;
 
             // Override per dev feedback
-            font-weight: 500;
             margin-bottom: 0.25rem;
 
             @media (min-width: @tablet-breakpoint) {
@@ -520,7 +519,6 @@ main {
                 line-height: normal;
 
                 // Override per dev feedback
-                font-weight: 500;
                 margin-bottom: 0;
             }
         }
@@ -621,14 +619,11 @@ main {
         padding-inline: 2rem;
         padding-top: 2.25rem;
         padding-bottom: 2rem;
-        max-width: 80rem;
+        max-width: 76rem;
     }
 
     i.ph {
         font-size: 1.5rem;
-        @media (min-width: @desktop-breakpoint) {
-            margin-left: 1rem;
-        }
 
         &.ph-pulse {
             color: var(--user-green);
@@ -651,7 +646,7 @@ main {
             align-items: start;
 
             // Supplied by Design
-            grid-template-columns: 20.5rem 1fr;
+            grid-template-columns: 18.25rem 1fr;
             column-gap: 1rem;
             row-gap: 2.25rem;
 
@@ -664,7 +659,7 @@ main {
             margin-bottom: 1.5rem;
 
             @media (min-width: @desktop-breakpoint) {
-                padding-inline: 2rem;
+                padding-inline: 0;
                 margin-bottom: 2rem;
                 grid-column: 1 / 4;
             }
@@ -721,8 +716,9 @@ main {
                 font-size: 2.25rem;
                 line-height: 120%;
                 letter-spacing: -0.025rem;
+                // per design QA
+                padding-left: 3.75rem; //  61px
 
-                padding-left: 5.75rem;
                 margin-bottom: 0;
 
                 gap: 1rem;
@@ -756,13 +752,8 @@ main {
             min-height: unset;
 
             @media (min-width: @tablet-breakpoint) {
-                padding-inline: 0.75rem;
-            }
-
-            &:has(.text) {
-                @media (min-width: @tablet-breakpoint) {
-                    padding-bottom: 1rem;
-                }
+                padding: 1rem;
+                padding-top: 0.75rem;
             }
 
             strong {


### PR DESCRIPTION
Numbering is from zeplin doc:

landing page changes:
- 7: set font-weight to 600 on card title

template (product/service page) changes:
- 17: #main-content max-width set to 76rem
- 30: padding on item cards set to 12px on top, 16px elsewhere
- 31: .product-roadmap-header padding-inline set to 0
- 32: removed margin-left from i.ph
- 33: changed h2 padding to 3.75rem
- 34: font-weight was already 600 on card title
- 35: .product-roadmap, changed grid-template-columns to 18.25rem 1fr
