### PR TITLE
Add TB desktop about:rights page to the website. (Fixes #1193)

### DIFF
--- a/sites/updates.thunderbird.net/thunderbird/about/rights/index.html
+++ b/sites/updates.thunderbird.net/thunderbird/about/rights/index.html
@@ -1,0 +1,138 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{# Standalone page — loaded inside a Thunderbird content tab via about:rights.
+   Served at https://updates.thunderbird.net/{locale}/thunderbird/about/rights/
+   No website header, footer, or navigation. #}
+
+<!DOCTYPE html>
+<html lang="{{ LANG }}" dir="{{ DIR }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ _('About Your Rights') }}</title>
+  <style>
+    body {
+      max-width: 48em;
+      margin: 2em auto;
+      padding: 0 1.5em;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #1a1a1a;
+      background: #fff;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { color: #e0e0e0; background: #1c1b22; }
+      a { color: #8cb4ff; }
+      a:visited { color: #b5a0ff; }
+    }
+    h1 { font-size: 1.5em; margin: 0 0 0.6em; }
+    h2 { font-size: 1.2em; margin: 1.4em 0 0.5em; }
+    h3 { font-size: 1em; margin: 1.2em 0 0.4em; }
+    ul, ol { padding-left: 2em; }
+    li { margin-bottom: 0.6em; }
+    a { color: #0060df; }
+    a:visited { color: #6e42a0; }
+  </style>
+</head>
+<body>
+  <h1>{{ _('About Your Rights') }}</h1>
+  <p>
+    {% trans trimmed %}
+      Thunderbird is free and open source software, built by a community of thousands from all over the world. There are a few things you should know:
+    {% endtrans %}
+  </p>
+  <ul>
+    <li>
+      {% trans trimmed mpl_url=url('mozorg.mpl2') %}
+        Thunderbird is made available to you under the terms of the <a href="{{ mpl_url }}">Mozilla Public License</a>. This means you may use, copy and distribute Thunderbird to others. You are also welcome to modify the source code of Thunderbird as you want to meet your needs. The Mozilla Public License also gives you the right to distribute your modified versions.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed trademark_url=url('legal.trademark') %}
+        You are not granted any trademark rights or licenses to the trademarks of the Mozilla Foundation or any party, including without limitation the Thunderbird name or logo. Additional information on trademarks may be found <a href="{{ trademark_url }}">here</a>.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        Some features in Thunderbird, such as the Crash Reporter, give you the option to provide feedback to Mozilla. By choosing to submit feedback, you give Mozilla permission to use the feedback to improve its products, to publish the feedback on its websites, and to distribute the feedback.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed privacy_url=url('thunderbird.privacy') %}
+        How we use your personal information and feedback submitted to Mozilla through Thunderbird is described in the <a href="{{ privacy_url }}">Thunderbird Privacy Policy</a>.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        Some Thunderbird features make use of web-based information services, however, we cannot guarantee they are 100% accurate or error-free. More details, including information on how to disable the features that use these services, can be found in the <a href="#webservices">service terms</a>.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        In order to play back certain types of video content, Thunderbird downloads certain content decryption modules from third parties.
+      {% endtrans %}
+    </li>
+  </ul>
+
+  <h2 id="webservices">{{ _('Thunderbird Web-Based Information Services') }}</h2>
+  <p>
+    {% trans trimmed %}
+      Thunderbird uses web-based information services ("Services") to provide some of the features provided for your use with this binary version of Thunderbird under the terms described below. If you do not want to use one or more of the Services or the terms below are unacceptable, you may disable the feature or Service(s). Instructions on how to disable a particular feature or Service may be found <a href="#disabling-webservices">here</a>. Other features and Services can be disabled in the application settings.
+    {% endtrans %}
+  </p>
+
+  <h3 id="disabling-webservices">{{ _('Location Aware Browsing') }}</h3>
+  <p>
+    {% trans trimmed %}
+      <strong>Location Aware Browsing:</strong> is always opt-in. No location information is ever sent without your permission. If you wish to disable the feature completely, follow these steps:
+    {% endtrans %}
+  </p>
+  <ul>
+    <li>{{ _('Open the Config Editor') }}</li>
+    <li>{{ _('Type geo.enabled') }}</li>
+    <li>{{ _('Double click on the geo.enabled preference') }}</li>
+    <li>{{ _('Location-Aware Browsing is now disabled') }}</li>
+  </ul>
+
+  <ol>
+    <li>
+      {% trans trimmed %}
+        Mozilla and its contributors, licensors and partners work to provide the most accurate and up-to-date Services. However, we cannot guarantee that this information is comprehensive and error-free. For example, the Safe Browsing Service may not identify some risky sites and may identify some safe sites in error and the Location Aware Service all locations returned by our service providers are estimates only and neither we nor our service providers guarantee the accuracy of the locations provided.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        Mozilla may discontinue or change the Services at its discretion.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        You are welcome to use these Services with the accompanying version of Thunderbird, and Mozilla grants you its rights to do so. Mozilla and its licensors reserve all other rights in the Services. These terms are not intended to limit any rights granted under open source licenses applicable to Thunderbird and to corresponding source code versions of Thunderbird.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        <strong>The Services are provided "as-is." Mozilla, its contributors, licensors, and distributors, disclaim all warranties, whether express or implied, including without limitation, warranties that the Services are merchantable and fit for your particular purposes. You bear the entire risk as to selecting the Services for your purposes and as to the quality and performance of the Services. Some jurisdictions do not allow the exclusion or limitation of implied warranties, so this disclaimer may not apply to you.</strong>
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        <strong>Except as required by law, Mozilla, its contributors, licensors, and distributors will not be liable for any indirect, special, incidental, consequential, punitive, or exemplary damages arising out of or in any way relating to the use of Thunderbird and the Services. The collective liability under these terms will not exceed $500 (five hundred dollars). Some jurisdictions do not allow the exclusion or limitation of certain damages, so this exclusion and limitation may not apply to you.</strong>
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        Mozilla may update these terms as necessary from time to time. These terms may not be modified or canceled without Mozilla's written agreement.
+      {% endtrans %}
+    </li>
+    <li>
+      {% trans trimmed %}
+        These terms are governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions. If any portion of these terms is held to be invalid or unenforceable, the remaining portions will remain in full force and effect. In the event of a conflict between a translated version of these terms and the English language version, the English language version shall control.
+      {% endtrans %}
+    </li>
+  </ol>
+</body>
+</html>


### PR DESCRIPTION
Move the about:rights content from Thunderbird's source to thunderbird.net.