### PR TITLE
Fix hover underline for footer legal links (#1132)

### DIFF
--- a/assets/less/common/common-footer.less
+++ b/assets/less/common/common-footer.less
@@ -111,7 +111,7 @@ footer#tb-footer {
     }
 }
 
-#tb-legal {
+footer#tb-footer #tb-legal {
     font-size: .75rem;
 
     a {

--- a/assets/less/common/common-footer.less
+++ b/assets/less/common/common-footer.less
@@ -115,6 +115,7 @@ footer#tb-footer #tb-legal {
     font-size: .75rem;
 
     a {
+        --accent: #1E4EAE;
         text-decoration: underline;
         text-decoration-color: currentColor;
 

--- a/assets/less/common/common-footer.less
+++ b/assets/less/common/common-footer.less
@@ -113,7 +113,14 @@ footer#tb-footer {
 
 #tb-legal {
     font-size: .75rem;
+
     a {
         text-decoration: underline;
+        text-decoration-color: currentColor;
+
+        &:hover,
+        &:focus {
+            text-decoration-color: var(--accent);
+        }
     }
 }


### PR DESCRIPTION
### Description

Fixes missing hover highlight for footer links in the legal section.

### Changes

* Added hover/focus styles for `#tb-legal a`
* Updated underline color on hover to provide visible feedback
* Scoped changes to legal section to avoid affecting other footer links

### Testing

* Ran local build using `uv run build-site.py --watch`
* Verified underline highlight on hover for:

  * MZLA Technologies Corporation
  * Creative Commons license
  * Contribute to this site
* Confirmed existing footer links remain unchanged

### Fixes

Closes #1132
