### PR TITLE
Fix(#1125) : Incorrect South Korean holiday name (Oct 3)

### DIFF
--- a/calgen/models/Calendarific.py
+++ b/calgen/models/Calendarific.py
@@ -44,6 +44,10 @@ class Calendarific(Calendar):
         else:
             self.name = data.get('name')
 
+        # Normalize incorrect South Korea holiday name returned by Calendarific API
+        if self.name == "건국일":
+            self.name = "개천절"
+
         description = data.get('description')
         primary_type = data.get('primary_type')
 


### PR DESCRIPTION
### Description

Corrects the name of the South Korean holiday on October 3rd.

The Calendarific API currently returns the holiday name as `건국일`, which is not the official designation. The correct name is `개천절` (Gaecheonjeol / National Foundation Day).

### Changes

* Added normalization logic in `Calendarific` model to replace `건국일` with `개천절`

### Testing

* Verified logic through code inspection
* Confirmed change is applied during calendar data parsing

### Notes

* This change ensures consistency with the official and legally recognized name of the holiday in South Korea

### Fixes

Closes #1125
