### PR TITLE
Route well-known paths at tb.pro domain to mail servers

### DIFF
--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -336,6 +336,20 @@ ScriptSock /tmp/cgisock
   Header always set X-Frame-Options "DENY"
 </VirtualHost>
 
+# thundermail.com
+<VirtualHost *:8080>
+  ServerName https://thundermail.com
+  ServerAlias www.thundermail.com stage-thundermail.com
+
+  # Rewrite well-known paths to our mail server
+  # https://github.com/thunderbird/mailstrom/issues/213
+  RewriteEngine On
+  RewriteRule ^/.well-known/(.*)$ https://mail.thundermail.com/.well-known/$1
+
+  # Rewrite all other requests to tb.pro site
+  RewriteRule ^.*$ https://tb.pro/
+</VirtualHost>
+
 # tb.pro
 <VirtualHost *:8080>
   ServerName https://tb.pro

--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -337,6 +337,11 @@ ScriptSock /tmp/cgisock
   ServerAlias www.tb.pro www-stage.tb.pro stage.tb.pro
   DocumentRoot /var/www/html/start/tb.pro
 
+  # Rewrite well-known paths to our mail server
+  # https://github.com/thunderbird/mailstrom/issues/213
+  RewriteEngine On
+  RewriteRule ^/.well-known/(.*)$ https://mail.thundermail.com/.well-known/$1
+
   <Directory "/var/www/html/start/tb.pro">
     AllowOverride All
     Options -Indexes +FollowSymLinks

--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -200,11 +200,6 @@ ScriptSock /tmp/cgisock
   ServerName https://thunderbird.net
   ServerAlias mozillamessaging.com www.mozillamessaging.com getthunderbird.com www.getthunderbird.com
 
-  # Rewrite well-known paths to our mail server
-  # https://github.com/thunderbird/mailstrom/issues/213
-  RewriteEngine On
-  RewriteRule ^/.well-known/(.*)$ https://mail.thundermail.com/.well-known/$1
-
   ExpiresActive On
   ExpiresDefault "access plus 6 hours"
   <Location />

--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -200,6 +200,11 @@ ScriptSock /tmp/cgisock
   ServerName https://thunderbird.net
   ServerAlias mozillamessaging.com www.mozillamessaging.com getthunderbird.com www.getthunderbird.com
 
+  # Rewrite well-known paths to our mail server
+  # https://github.com/thunderbird/mailstrom/issues/213
+  RewriteEngine On
+  RewriteRule ^/.well-known/(.*)$ https://mail.thundermail.com/.well-known/$1
+
   ExpiresActive On
   ExpiresDefault "access plus 6 hours"
   <Location />


### PR DESCRIPTION
Adds a rewrite rule to the httpd config which will send requests originally bound for `tb.pro/.well-known/whatever` to `mail.thundermail.com/.well-known/whatever` instead.