### PR TITLE
Fix language redirect for terms and privacy

### DIFF
--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -375,7 +375,9 @@ ScriptSock /tmp/cgisock
   # URLs with no language code need to be assigned one by wsgi.py
   WSGIScriptAliasMatch ^/$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/appointment[/]?$ /var/www/html/start/wsgi.py
+  WSGIScriptAliasMatch ^/privacy[/]?$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/send[/]?$ /var/www/html/start/wsgi.py
+  WSGIScriptAliasMatch ^/terms[/]?$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/thundermail[/]?$ /var/www/html/start/wsgi.py
   WSGIScriptAliasMatch ^/waitlist[/]?$ /var/www/html/start/wsgi.py
   # Bug 1862171

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -142,6 +142,12 @@ LOCALE_TESTS = [
     ("tb.pro", "/waitlist", "en-US", "/en-US/waitlist"),
     ("tb.pro", "/waitlist", "fr", "/fr/waitlist"),
     ("tb.pro", "/waitlist", "ja", "/ja/waitlist"),
+    ("tb.pro", "/privacy", "en-US", "/en-US/privacy"),
+    ("tb.pro", "/privacy", "fr", "/fr/privacy"),
+    ("tb.pro", "/privacy", "ja", "/ja/privacy"),
+    ("tb.pro", "/terms", "en-US", "/en-US/terms"),
+    ("tb.pro", "/terms", "fr", "/fr/terms"),
+    ("tb.pro", "/terms", "ja", "/ja/terms"),
 
     # support.thunderbird.net - redirect is locale-agnostic regardless of Accept-Language (issue #1135)
     ("support.thunderbird.net", "/thunderbird/147.0.2/Linux/en-US/quarantined-domains", "en-US", "support.mozilla.org/kb/quarantined-domains"),


### PR DESCRIPTION
Navigating to tb.pro/terms and tb.pro/privacy (without the lang) fails, so adding a WSGI rule for both + tests

Ref https://github.com/thunderbird/thunderbird-accounts/issues/803
Fixes https://github.com/thunderbird/thunderbird-website/issues/1212

One can test this by navigating to

https://fix-lang-redirect-terms-privac-1210-kestrel.thunderbird.dev/terms
https://fix-lang-redirect-terms-privac-1210-kestrel.thunderbird.dev/privacy

which would redirect to 

https://fix-lang-redirect-terms-privac-1210-kestrel.thunderbird.dev/en-US/terms
https://fix-lang-redirect-terms-privac-1210-kestrel.thunderbird.dev/en-US/privacy