### PR TITLE
Allow tab-navigation-bar link to be clickable even when active

### DIFF
--- a/sites/common/includes/base/tab-navigation-bar.html
+++ b/sites/common/includes/base/tab-navigation-bar.html
@@ -32,9 +32,6 @@
     // Force-highlight www link for roadmaps site.
     if ((linkHost === currentHost) || isRoadmaps) {
       link.classList.add('active');
-      link.addEventListener('click', (e) => {
-        e.preventDefault();
-      });
     } else {
       // Remove active class from other links
       link.classList.remove('active');


### PR DESCRIPTION
We were preventing the click for the active item in the tab-navigation-bar but for the current page architecture (Thundermail > Appointment / Send), it is nice to be able to go back to Thundermail by clicking the top nav.

Note: Just realized that this is not preview-able unfortunately :(

Closes https://github.com/thunderbird/thunderbird-website/issues/1249