### PR TITLE
Don't do locale redirects for tb.pro for now

### DIFF
--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -139,15 +139,17 @@ LOCALE_TESTS = [
     ("www.thunderbird.net", "/", "en-US", "/en-US/"),
     ("www.thunderbird.net", "/", "fr", "/fr/"),
     ("www.thunderbird.net", "/", "ja", "/ja/"),
+    # tb.pro doesn't have translations for all strings yet, so it always
+    # redirects to en-US regardless of Accept-Language.
     ("tb.pro", "/waitlist", "en-US", "/en-US/waitlist"),
-    ("tb.pro", "/waitlist", "fr", "/fr/waitlist"),
-    ("tb.pro", "/waitlist", "ja", "/ja/waitlist"),
+    ("tb.pro", "/waitlist", "fr", "/en-US/waitlist"),
+    ("tb.pro", "/waitlist", "ja", "/en-US/waitlist"),
     ("tb.pro", "/privacy", "en-US", "/en-US/privacy"),
-    ("tb.pro", "/privacy", "fr", "/fr/privacy"),
-    ("tb.pro", "/privacy", "ja", "/ja/privacy"),
+    ("tb.pro", "/privacy", "fr", "/en-US/privacy"),
+    ("tb.pro", "/privacy", "ja", "/en-US/privacy"),
     ("tb.pro", "/terms", "en-US", "/en-US/terms"),
-    ("tb.pro", "/terms", "fr", "/fr/terms"),
-    ("tb.pro", "/terms", "ja", "/ja/terms"),
+    ("tb.pro", "/terms", "fr", "/en-US/terms"),
+    ("tb.pro", "/terms", "ja", "/en-US/terms"),
 
     # support.thunderbird.net - redirect is locale-agnostic regardless of Accept-Language (issue #1135)
     ("support.thunderbird.net", "/thunderbird/147.0.2/Linux/en-US/quarantined-domains", "en-US", "support.mozilla.org/kb/quarantined-domains"),

--- a/wsgi.py
+++ b/wsgi.py
@@ -75,7 +75,13 @@ def application(environ, start_response):
     # Are we updates.thunderbird.net?
     is_utn = any(['updates.' in req.host_url, 'updates-stage.' in req.host_url])
 
-    if (not is_utn
+    # tb.pro doesn't have translations for all strings yet, so always serve
+    # en-US regardless of the visitor's Accept-Language header.
+    is_tbpro = 'tb.pro' in req.host_url
+
+    if is_tbpro:
+        language_code = 'en-US'
+    elif (not is_utn
         and 'thunderbird' in req.path
         and not any(s in req.path for s in settings.ALWAYS_LOCALIZE)):
         # Release notes, system requirements, and 'all' builds pages are only available in English.


### PR DESCRIPTION
We don't have translation strings for tb.pro just yet and it is still a topic of discussion on how to achieve this so this PR forces the locale to be en-US instead so that the pages don't look half-translated when we use shared strings.