### PR TITLE
Add remaining release channels to the no-JS downloads page

### DIFF
--- a/build-site.py
+++ b/build-site.py
@@ -186,7 +186,9 @@ def build_main_website():
     print(f'Rendering www.thunderbird.net {langmsg}')
     default_channel = settings.DEFAULT_RELEASE_VERSION
     version = helper.thunderbird_desktop.latest_version(default_channel)
+    esr_version = helper.thunderbird_desktop.latest_version('esr')
     beta_version = helper.thunderbird_desktop.latest_version('beta')
+    daily_version = helper.thunderbird_desktop.latest_version('daily')
 
     if os.path.exists('media/caldata/autogen/calendars.json'):
         caldata = helper.load_calendar_json('media/caldata/autogen/calendars.json')
@@ -199,15 +201,19 @@ def build_main_website():
         'query': '',
         'platforms': helper.thunderbird_desktop.platforms('release'),
         'full_builds_version': version.split('.', 1)[0],
+        'full_builds_esr': helper.thunderbird_desktop.get_filtered_full_builds('esr', esr_version),
         'full_builds': helper.thunderbird_desktop.get_filtered_full_builds('release', version),
         'full_builds_beta': helper.thunderbird_desktop.get_filtered_full_builds('beta', beta_version),
+        'full_builds_daily': helper.thunderbird_desktop.get_filtered_full_builds('daily', daily_version),
         'channel_label': 'Thunderbird',
         'releases': helper.thunderbird_desktop.list_releases(),
         'calendars': caldata['calendars'],
         'letters': caldata['letters'],
         'CALDATA_URL': settings.CALDATA_URL,
         'latest_thunderbird_version': version,
+        'latest_thunderbird_esr_version': esr_version,
         'latest_thunderbird_beta_version': beta_version,
+        'latest_thunderbird_daily_version': daily_version,
         'blog_data': [],
         'default_channel': default_channel
     }

--- a/sites/www.thunderbird.net/thunderbird/all/index.html
+++ b/sites/www.thunderbird.net/thunderbird/all/index.html
@@ -221,7 +221,7 @@
       </div>
     </div>
 
-    {# No javascript / source of truth for esr download links #}
+    {# No javascript / source of truth for all channel download links #}
     <div id="all-downloads" data-thunderbird-version="{{ latest_thunderbird_version }}">
       <div class="section-text">
         <h2 class="split-text" aria-label="{{ _('Thunderbird Mobile.') }}" style="justify-content: center">
@@ -254,8 +254,45 @@
           {% endfor -%}
         </ul>
       </div>
-      <div class="all-downloads-container">
-        {{ build_table(platforms, full_builds) }}
+
+      {# ESR channel #}
+      <div data-channel="esr" class="all-downloads-channel">
+        <div class="section-text">
+          <h3>{{ _('Extended Support Release') }} — {{ latest_thunderbird_esr_version }}</h3>
+        </div>
+        <div class="all-downloads-container">
+          {{ build_table(platforms, full_builds_esr) }}
+        </div>
+      </div>
+
+      {# Release channel #}
+      <div data-channel="release" class="all-downloads-channel">
+        <div class="section-text">
+          <h3>{{ _('Release') }} — {{ latest_thunderbird_version }}</h3>
+        </div>
+        <div class="all-downloads-container">
+          {{ build_table(platforms, full_builds) }}
+        </div>
+      </div>
+
+      {# Beta channel #}
+      <div data-channel="beta" class="all-downloads-channel">
+        <div class="section-text">
+          <h3>{{ _('Beta') }} — {{ latest_thunderbird_beta_version }}</h3>
+        </div>
+        <div class="all-downloads-container">
+          {{ build_table(platforms, full_builds_beta) }}
+        </div>
+      </div>
+
+      {# Daily channel #}
+      <div data-channel="daily" class="all-downloads-channel">
+        <div class="section-text">
+          <h3>{{ _('Daily') }} — {{ latest_thunderbird_daily_version }}</h3>
+        </div>
+        <div class="all-downloads-container">
+          {{ build_table(platforms, full_builds_daily) }}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

This PR adds the remaining Thunderbird release channels to the no-JS downloads page.

### Changes
- Added Extended Support Release (ESR) downloads
- Added Release downloads
- Added Beta downloads
- Added Daily downloads
- Added `data-channel` wrappers for each section
- Passed the required build data from `build-site.py`

### Testing
- Built the website using:
  - `uv run build-site.py`
  - `uv run build-site.py --watch`
- Verified the site builds successfully without template errors.
- Verified the new channel sections render correctly.

Fixes #837