### PR TITLE
Add "esr" to the release urls of product-details key ending with "esr"

### DIFF
--- a/product_details.py
+++ b/product_details.py
@@ -259,8 +259,12 @@ class ThunderbirdDetails():
 
             is_major = category == 'major' or needs_major_fixup(version_int)
             is_stability = category == 'stability'
-            # We only count 128.0 and up as esr (and specific 115.0 versions)
-            is_esr = (category == 'esr' and version_int[0] >= 128) or needs_esr_fixup(version_int)
+
+            # We only count 128.0 and up as esr (and specific 115.0 versions).
+            # product-details sometimes mislabels the category for esr builds (e.g. the
+            # entire 140.x esr line is tagged 'stability'), so also trust the "esr" suffix
+            # on the product-details key itself, which seems to be applied consistently.
+            is_esr = (version_int[0] >= 128 and (category == 'esr' or key.endswith('esr'))) or needs_esr_fixup(version_int)
 
             # Skip non-esr builds between 115 and 136 since monthly releases were in beta
             if not is_esr and 115 < version_int[0] < 136:

--- a/tests/test_product_details.py
+++ b/tests/test_product_details.py
@@ -47,3 +47,21 @@ class TestListReleases:
 
         assert 128.0 in list_releases_result
         assert '128.0.1esr' in list_releases_result[128.0]['minor']
+
+    def test_esr_key_used_when_category_mislabeled(self):
+        """product-details sometimes mislabels esr builds' category as 'stability' instead of 'esr'
+        (this happened for the whole 140.x esr line). We should still detect them as esr via the
+        "esr" suffix on the product-details key itself, so the releases page links to the
+        version that actually has release notes (e.g. 140.12.1esr, not 140.12.1)."""
+        thunderbird_desktop.releases = {
+            'releases': {
+                'thunderbird-140.0': {'category': 'major', 'version': '140.0'},
+                'thunderbird-140.12.1esr': {'category': 'stability', 'version': '140.12.1'},
+            }
+        }
+
+        list_releases_result = dict(thunderbird_desktop.list_releases())
+
+        assert 140.0 in list_releases_result
+        assert '140.12.1esr' in list_releases_result[140.0]['minor']
+        assert '140.12.1' not in list_releases_result[140.0]['minor']


### PR DESCRIPTION
Essentially adding an `or key.endswith('esr')` to the `is_esr` condition when listing releases.

Also, it seems that we no longer can use the `category` reliably to determine whether or not the release is ESR and should have the ESR appended in the URL:

https://github.com/mozilla-releng/product-details/commit/fa5a8e0227e824b1e2a6d9f7361a9f2a92f4d87f

This is the JSON for reference of the keys: https://product-details.mozilla.org/1.0/thunderbird.json
Extra info, from bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1966320

Closes https://github.com/thunderbird/thunderbird-website/issues/1261