### PR TITLE
Pause animations in appeals if window / tab not in focus

### DIFF
--- a/assets/js/common/animation-visibility.js
+++ b/assets/js/common/animation-visibility.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Toggles a `tab-inactive` class on the <html> element whenever the tab is
+ * hidden (Page Visibility API) or the window loses focus (e.g. the user
+ * switched to another application). CSS can key off this class to pause
+ * decorative animations (e.g. `animation-play-state: paused`) and avoid
+ * burning CPU/battery while the page isn't actually being looked at.
+ */
+(() => {
+  const root = document.documentElement;
+
+  const updateAnimationVisibility = () => {
+    const isInactive = document.hidden || !document.hasFocus();
+    root.classList.toggle('tab-inactive', isInactive);
+  };
+
+  document.addEventListener('visibilitychange', updateAnimationVisibility);
+  window.addEventListener('blur', updateAnimationVisibility);
+  window.addEventListener('focus', updateAnimationVisibility);
+
+  updateAnimationVisibility();
+})();

--- a/assets/less/appeals/apr25.less
+++ b/assets/less/appeals/apr25.less
@@ -56,6 +56,11 @@
       background: var(--bg-img);
       background-size: 100% 100%;
     }
+
+    // Pause the gradient animation while the tab isn't visible or focused.
+    :root.tab-inactive & {
+      animation-play-state: paused;
+    }
   }
 
   #appeal-header {

--- a/assets/less/appeals/apr25.less
+++ b/assets/less/appeals/apr25.less
@@ -40,6 +40,11 @@
 // Scope to just the appeal page
 .page-appeal-apr25 {
 
+  // Pause the gradient animation while the tab isn't visible or focused.
+  &.tab-inactive body {
+    animation-play-state: paused;
+  }
+
   body {
     margin: auto;
     min-width: var(--min-small-screen);
@@ -55,11 +60,6 @@
       animation: none;
       background: var(--bg-img);
       background-size: 100% 100%;
-    }
-
-    // Pause the gradient animation while the tab isn't visible or focused.
-    :root.tab-inactive & {
-      animation-play-state: paused;
     }
   }
 

--- a/assets/less/appeals/apr26-1e.less
+++ b/assets/less/appeals/apr26-1e.less
@@ -8,6 +8,11 @@
 .page-appeal-dec25 {
   background-color: #ffc068;
 
+  // Pause the gradient animation while the tab isn't visible or focused.
+  &.tab-inactive body {
+    animation-play-state: paused;
+  }
+
   body {
     max-width: none;
     min-width: var(--min-small-screen);
@@ -19,11 +24,6 @@
       animation: none;
       background: var(--bg-img);
       background-size: 100% 100%;
-    }
-
-    // Pause the gradient animation while the tab isn't visible or focused.
-    :root.tab-inactive & {
-      animation-play-state: paused;
     }
   }
 

--- a/assets/less/appeals/apr26-1e.less
+++ b/assets/less/appeals/apr26-1e.less
@@ -20,6 +20,11 @@
       background: var(--bg-img);
       background-size: 100% 100%;
     }
+
+    // Pause the gradient animation while the tab isn't visible or focused.
+    :root.tab-inactive & {
+      animation-play-state: paused;
+    }
   }
 
   #header-gradient {

--- a/assets/less/appeals/apr26.less
+++ b/assets/less/appeals/apr26.less
@@ -691,4 +691,19 @@ body {
       transform: translateY(0) !important;
     }
   }
+
+  // ==========================================
+  // Pause animations while the tab isn't visible or focused
+  // ==========================================
+
+  &.tab-inactive {
+    #appeal-body {
+      animation-play-state: paused;
+
+      #cloud div::before,
+      #cloud div::after {
+        animation-play-state: paused;
+      }
+    }
+  }
 }

--- a/assets/less/new/components/donate-cta.less
+++ b/assets/less/new/components/donate-cta.less
@@ -174,6 +174,11 @@
   }
 }
 
+// Pause the floating pills while the tab isn't visible or focused.
+:root.tab-inactive .pill {
+  animation-play-state: paused !important;
+}
+
 #pill-1 {
   grid-column: 4 / span 8;
   grid-row: 5 / span 3;

--- a/settings.py
+++ b/settings.py
@@ -471,7 +471,8 @@ UPDATES_JS = {
         # Necessary for the download button to select the correct platform.
         'js/base/site.js',
         # Load bearing order..Donation must come before AB testing.
-        'js/common/donations.js', 'js/common/ab-testing.js', 'js/common/donation-notice.js'
+        'js/common/donations.js', 'js/common/ab-testing.js', 'js/common/donation-notice.js',
+        'js/common/animation-visibility.js'
     ]
 }
 


### PR DESCRIPTION
## Description of changes

- Added an `animation-visibility.js` script to add an event handler and toggle the `tab-inactive` class in the `documentElement`.
- Updated donation button CSS, `128.0/apr25/` and `140.0/apr26-1a/` and `140.0/apr26-1c/

Relevant preview links:
https://davinotdavid-pause-animations--1267-whimbrel.thunderbird.dev/en-US/thunderbird/128.0/apr25/
https://davinotdavid-pause-animations--1267-whimbrel.thunderbird.dev/en-US/thunderbird/140.0/apr26-1a/
https://davinotdavid-pause-animations--1267-whimbrel.thunderbird.dev/en-US/thunderbird/140.0/apr26-1c/

## Limitations and notes

- This does not improve the performance while the tab is active. There's a much longer / deeper research and refactor required for this that's out of scope of this task.

## Videos

Focus on the tab vs focus on DevTools toggles the pause animation:

https://github.com/user-attachments/assets/1e4f2c18-0e77-45a8-80c9-a8f77acc41df



Profiling GPU process in Chrome by switching tabs:

https://github.com/user-attachments/assets/b632901d-367b-45fe-87b1-06e5fed608c4


## Related issues

Closes https://github.com/thunderbird/thunderbird-website/issues/1266