### PR TITLE
Update flathub reference

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -263,7 +263,7 @@ URL_MAPPINGS = {
     'download.android.compatibility': 'https://github.com/thunderbird/thunderbird-android/wiki/ReleaseNotes#minimum-android-version-compatibility',
     'download.android.changelog': 'https://github.com/thunderbird/thunderbird-android/releases?q=prerelease:false',
     'download.desktop.choosing-release-channel': 'https://support.mozilla.org/kb/choosing-thunderbird-release-channel',
-    'download.desktop.flathub': 'https://flathub.org/apps/org.mozilla.Thunderbird',
+    'download.desktop.flathub': 'https://flathub.org/apps/org.mozilla.thunderbird',
     'download.desktop.msstore': 'https://apps.microsoft.com/detail/9pm5vm1s3vmq',
     'download.desktop.snap': 'https://snapcraft.io/thunderbird',
     'firefox.dnt': 'https://www.mozilla.org/firefox/dnt/',


### PR DESCRIPTION
Changing it to be lower cased. We should probably also expose the ESR flathub link separately? That's what the old ID redirects to currently anyway.