### PR TITLE
Fix bug 1274 by preserving URL params in redirect from thundermail.com to tb.pro

### DIFF
--- a/docker/conf/ssl.conf
+++ b/docker/conf/ssl.conf
@@ -342,7 +342,7 @@ ScriptSock /tmp/cgisock
   RewriteRule ^/.well-known/(.*)$ https://mail.thundermail.com/.well-known/$1 [R=302,L]
 
   # Rewrite all other requests to tb.pro site
-  RewriteRule ^.*$ https://tb.pro/ [R=302,L]
+  RewriteRule ^(.*)$ https://tb.pro$1 [R=302,L,QSA]
 </VirtualHost>
 
 # tb.pro


### PR DESCRIPTION
Fix bug 1274 by preserving URL params in redirect from thundermail.com to tb.pro

Changed ssl.conf