### PR TITLE
Fix "Join the repository" hyperlink on Participate > Desktop Development

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -284,7 +284,7 @@ URL_MAPPINGS = {
     'mozwiki.support-languages': 'https://wiki.mozilla.org/Thunderbird/Support/Community_support_based_on_languages',
     'mzla.blog-post': 'https://blog.thunderbird.net/2020/01/thunderbirds-new-home/',
     'participate.desktop.docs': 'https://developer.thunderbird.net/',
-    'participate.desktop.repo': 'https://developer.thunderbird.net/thunderbird-development/getting-started',
+    'participate.desktop.repo': 'https://github.com/thunderbird/thunderbird-desktop',
     'participate.desktop.matrix': 'https://matrix.to/#/#maildev:mozilla.org',
     'participate.android.docs': 'https://github.com/thunderbird/thunderbird-android/tree/main/docs',
     'participate.android.repo': 'https://github.com/thunderbird/thunderbird-android',


### PR DESCRIPTION
**Summary**
- The "Join the repository" link under Code > Desktop Development on the Participate page redirected to the docs getting-started page instead of the actual repo. Updated the `participate.desktop.repo` URL mapping to point to https://github.com/thunderbird/thunderbird-desktop.

**Steps to reproduce (before fix)**
1. Go to https://www.thunderbird.net/en-US/participate/
2. Scroll to Code > Desktop Development
3. Clicking "Join the repository" redirects to https://developer.thunderbird.net/thunderbird-development/getting-started instead of the repo

Fixes issue #1291