### PR TITLE
Preview: do not cancel in-progress deploys

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,9 +39,12 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
+    # Never cancel a running deploy: interrupting `pulumi up` orphans
+    # half-created AWS resources that later runs cannot reconcile.
+    # Superseded pending runs are still dropped by the concurrency group.
     concurrency:
       group: preview-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Set `cancel-in-progress: false` on the preview deploy job. Cancelling `pulumi up` mid-run leaves orphaned AWS resources that later deploys/destroys can't reconcile (see #1294, where an orphaned Lambda blocked every subsequent preview deploy with a 409). Superseded pending runs are still dropped by the concurrency group, so a burst of pushes costs at most one extra run.